### PR TITLE
Add license removal when disabling inactive users

### DIFF
--- a/src/sjifire/entra/aladtec_import.py
+++ b/src/sjifire/entra/aladtec_import.py
@@ -212,20 +212,29 @@ class AladtecImporter:
                             "member": member.display_name,
                             "email": member.email,
                             "user_id": existing.id,
+                            "action": "would disable and remove licenses",
                         }
                     )
-                    logger.info(f"Would disable: {member.display_name}")
+                    logger.info(f"Would disable and remove licenses: {member.display_name}")
                 else:
-                    success = await self.user_manager.disable_user(existing.id)
-                    if success:
+                    disable_ok, license_ok = await self.user_manager.disable_and_remove_licenses(
+                        existing.id
+                    )
+                    if disable_ok:
                         result.disabled.append(
                             {
                                 "member": member.display_name,
                                 "email": member.email,
                                 "user_id": existing.id,
+                                "licenses_removed": license_ok,
                             }
                         )
-                        logger.info(f"Disabled: {member.display_name}")
+                        if license_ok:
+                            logger.info(f"Disabled and removed licenses: {member.display_name}")
+                        else:
+                            logger.warning(
+                                f"Disabled {member.display_name} but failed to remove licenses"
+                            )
                     else:
                         result.errors.append(
                             {

--- a/tests/test_entra_users.py
+++ b/tests/test_entra_users.py
@@ -1,6 +1,9 @@
 """Tests for sjifire.entra.users."""
 
 import string
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from sjifire.entra.users import EntraUser, EntraUserManager
 
@@ -130,3 +133,183 @@ class TestEntraUserManagerUPNGeneration:
         upn = manager.generate_upn("John", "Doe")
 
         assert upn == "john.doe@example.com"
+
+
+class TestEntraUserManagerLicenseManagement:
+    """Tests for license management methods."""
+
+    @pytest.fixture
+    def manager(self, mock_env_vars):
+        """Create a manager with mocked client."""
+        mgr = EntraUserManager.__new__(EntraUserManager)
+        mgr.domain = "sjifire.org"
+        mgr.client = MagicMock()
+        return mgr
+
+    async def test_get_user_licenses_returns_sku_ids(self, manager):
+        """Should return list of SKU ID strings."""
+        # Mock license details response - must use valid UUIDs
+        mock_license1 = MagicMock()
+        mock_license1.sku_id = "f30db892-07e9-47e9-837c-80727f46fd3d"
+        mock_license2 = MagicMock()
+        mock_license2.sku_id = "84a661c4-e949-4bd2-a560-ed7766fcaf2b"
+
+        mock_result = MagicMock()
+        mock_result.value = [mock_license1, mock_license2]
+
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+
+        licenses = await manager.get_user_licenses("user-123")
+
+        assert licenses == [
+            "f30db892-07e9-47e9-837c-80727f46fd3d",
+            "84a661c4-e949-4bd2-a560-ed7766fcaf2b",
+        ]
+        manager.client.users.by_user_id.assert_called_with("user-123")
+
+    async def test_get_user_licenses_returns_empty_list_when_no_licenses(self, manager):
+        """Should return empty list when user has no licenses."""
+        mock_result = MagicMock()
+        mock_result.value = []
+
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+
+        licenses = await manager.get_user_licenses("user-123")
+
+        assert licenses == []
+
+    async def test_get_user_licenses_handles_none_result(self, manager):
+        """Should return empty list when API returns None."""
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=None
+        )
+
+        licenses = await manager.get_user_licenses("user-123")
+
+        assert licenses == []
+
+    async def test_get_user_licenses_handles_error(self, manager):
+        """Should return empty list on API error."""
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            side_effect=Exception("API error")
+        )
+
+        licenses = await manager.get_user_licenses("user-123")
+
+        assert licenses == []
+
+    async def test_remove_all_licenses_success(self, manager):
+        """Should remove all licenses and return True."""
+        # Mock get_user_licenses - must use valid UUID
+        mock_license = MagicMock()
+        mock_license.sku_id = "f30db892-07e9-47e9-837c-80727f46fd3d"
+        mock_result = MagicMock()
+        mock_result.value = [mock_license]
+
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+        manager.client.users.by_user_id.return_value.assign_license.post = AsyncMock(
+            return_value=None
+        )
+
+        result = await manager.remove_all_licenses("user-123")
+
+        assert result is True
+        manager.client.users.by_user_id.return_value.assign_license.post.assert_called_once()
+
+    async def test_remove_all_licenses_returns_true_when_no_licenses(self, manager):
+        """Should return True when user has no licenses to remove."""
+        mock_result = MagicMock()
+        mock_result.value = []
+
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+
+        result = await manager.remove_all_licenses("user-123")
+
+        assert result is True
+
+    async def test_remove_all_licenses_returns_false_on_error(self, manager):
+        """Should return False when license removal fails."""
+        mock_license = MagicMock()
+        mock_license.sku_id = "f30db892-07e9-47e9-837c-80727f46fd3d"
+        mock_result = MagicMock()
+        mock_result.value = [mock_license]
+
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+        manager.client.users.by_user_id.return_value.assign_license.post = AsyncMock(
+            side_effect=Exception("API error")
+        )
+
+        result = await manager.remove_all_licenses("user-123")
+
+        assert result is False
+
+    async def test_disable_and_remove_licenses_both_succeed(self, manager):
+        """Should return (True, True) when both operations succeed."""
+        # Mock disable_user
+        manager.client.users.by_user_id.return_value.patch = AsyncMock(return_value=None)
+
+        # Mock license removal (no licenses)
+        mock_result = MagicMock()
+        mock_result.value = []
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+
+        disable_ok, license_ok = await manager.disable_and_remove_licenses("user-123")
+
+        assert disable_ok is True
+        assert license_ok is True
+
+    async def test_disable_and_remove_licenses_disable_fails(self, manager):
+        """Should return (False, ...) when disable fails."""
+        # Mock disable_user to fail
+        manager.client.users.by_user_id.return_value.patch = AsyncMock(
+            side_effect=Exception("API error")
+        )
+
+        # Mock license removal (no licenses)
+        mock_result = MagicMock()
+        mock_result.value = []
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+
+        disable_ok, license_ok = await manager.disable_and_remove_licenses("user-123")
+
+        assert disable_ok is False
+        # License removal still attempted
+        assert license_ok is True
+
+    async def test_disable_and_remove_licenses_license_removal_fails(self, manager):
+        """Should return (True, False) when license removal fails."""
+        # Mock disable_user to succeed
+        manager.client.users.by_user_id.return_value.patch = AsyncMock(return_value=None)
+
+        # Mock license details to return a license - must use valid UUID
+        mock_license = MagicMock()
+        mock_license.sku_id = "f30db892-07e9-47e9-837c-80727f46fd3d"
+        mock_result = MagicMock()
+        mock_result.value = [mock_license]
+        manager.client.users.by_user_id.return_value.license_details.get = AsyncMock(
+            return_value=mock_result
+        )
+
+        # Mock assign_license to fail
+        manager.client.users.by_user_id.return_value.assign_license.post = AsyncMock(
+            side_effect=Exception("API error")
+        )
+
+        disable_ok, license_ok = await manager.disable_and_remove_licenses("user-123")
+
+        assert disable_ok is True
+        assert license_ok is False


### PR DESCRIPTION
## Summary

- When disabling inactive Aladtec members, automatically remove their M365 licenses to free up license costs
- Add `--cleanup-disabled-licenses` CLI flag to retroactively remove licenses from already-disabled users

## Changes

### New Methods in `users.py`
- `get_user_licenses()` - Fetch user's assigned license SKU IDs via Graph API
- `remove_all_licenses()` - Remove all licenses from a user
- `disable_and_remove_licenses()` - Disable account + remove licenses in one call

### Updated Sync Flow
- `aladtec_import.py` now calls `disable_and_remove_licenses()` instead of just `disable_user()`
- Reports `licenses_removed` status in results

### New CLI Option
- `entra-sync --cleanup-disabled-licenses` - Find all disabled users and remove their licenses
- Supports `--dry-run` to preview what would happen

## Test plan

- [x] 166 tests passing
- [x] Tested `--cleanup-disabled-licenses --dry-run` against production
- [x] Tested `--cleanup-disabled-licenses` - successfully removed licenses from 2 disabled users