### PR TITLE
Mask secrets in workflow logs

### DIFF
--- a/.github/workflows/entra-sync.yml
+++ b/.github/workflows/entra-sync.yml
@@ -37,12 +37,29 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            echo "ALADTEC_URL=$(az keyvault secret show --vault-name gh-website-utilities --name ALADTEC-URL --query value -o tsv)" >> $GITHUB_ENV
-            echo "ALADTEC_USERNAME=$(az keyvault secret show --vault-name gh-website-utilities --name ALADTEC-USERNAME --query value -o tsv)" >> $GITHUB_ENV
-            echo "ALADTEC_PASSWORD=$(az keyvault secret show --vault-name gh-website-utilities --name ALADTEC-PASSWORD --query value -o tsv)" >> $GITHUB_ENV
-            echo "MS_GRAPH_TENANT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-TENANT-ID --query value -o tsv)" >> $GITHUB_ENV
-            echo "MS_GRAPH_CLIENT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-ID --query value -o tsv)" >> $GITHUB_ENV
-            echo "MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)" >> $GITHUB_ENV
+            ALADTEC_URL=$(az keyvault secret show --vault-name gh-website-utilities --name ALADTEC-URL --query value -o tsv)
+            echo "::add-mask::$ALADTEC_URL"
+            echo "ALADTEC_URL=$ALADTEC_URL" >> $GITHUB_ENV
+
+            ALADTEC_USERNAME=$(az keyvault secret show --vault-name gh-website-utilities --name ALADTEC-USERNAME --query value -o tsv)
+            echo "::add-mask::$ALADTEC_USERNAME"
+            echo "ALADTEC_USERNAME=$ALADTEC_USERNAME" >> $GITHUB_ENV
+
+            ALADTEC_PASSWORD=$(az keyvault secret show --vault-name gh-website-utilities --name ALADTEC-PASSWORD --query value -o tsv)
+            echo "::add-mask::$ALADTEC_PASSWORD"
+            echo "ALADTEC_PASSWORD=$ALADTEC_PASSWORD" >> $GITHUB_ENV
+
+            MS_GRAPH_TENANT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-TENANT-ID --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_TENANT_ID"
+            echo "MS_GRAPH_TENANT_ID=$MS_GRAPH_TENANT_ID" >> $GITHUB_ENV
+
+            MS_GRAPH_CLIENT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-ID --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_CLIENT_ID"
+            echo "MS_GRAPH_CLIENT_ID=$MS_GRAPH_CLIENT_ID" >> $GITHUB_ENV
+
+            MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_CLIENT_SECRET"
+            echo "MS_GRAPH_CLIENT_SECRET=$MS_GRAPH_CLIENT_SECRET" >> $GITHUB_ENV
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ispyfire-sync.yml
+++ b/.github/workflows/ispyfire-sync.yml
@@ -37,12 +37,29 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            echo "MS_GRAPH_TENANT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-TENANT-ID --query value -o tsv)" >> $GITHUB_ENV
-            echo "MS_GRAPH_CLIENT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-ID --query value -o tsv)" >> $GITHUB_ENV
-            echo "MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)" >> $GITHUB_ENV
-            echo "ISPYFIRE_URL=$(az keyvault secret show --vault-name gh-website-utilities --name ISPYFIRE-URL --query value -o tsv)" >> $GITHUB_ENV
-            echo "ISPYFIRE_USERNAME=$(az keyvault secret show --vault-name gh-website-utilities --name ISPYFIRE-USERNAME --query value -o tsv)" >> $GITHUB_ENV
-            echo "ISPYFIRE_PASSWORD=$(az keyvault secret show --vault-name gh-website-utilities --name ISPYFIRE-PASSWORD --query value -o tsv)" >> $GITHUB_ENV
+            MS_GRAPH_TENANT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-TENANT-ID --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_TENANT_ID"
+            echo "MS_GRAPH_TENANT_ID=$MS_GRAPH_TENANT_ID" >> $GITHUB_ENV
+
+            MS_GRAPH_CLIENT_ID=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-ID --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_CLIENT_ID"
+            echo "MS_GRAPH_CLIENT_ID=$MS_GRAPH_CLIENT_ID" >> $GITHUB_ENV
+
+            MS_GRAPH_CLIENT_SECRET=$(az keyvault secret show --vault-name gh-website-utilities --name MS-GRAPH-CLIENT-SECRET --query value -o tsv)
+            echo "::add-mask::$MS_GRAPH_CLIENT_SECRET"
+            echo "MS_GRAPH_CLIENT_SECRET=$MS_GRAPH_CLIENT_SECRET" >> $GITHUB_ENV
+
+            ISPYFIRE_URL=$(az keyvault secret show --vault-name gh-website-utilities --name ISPYFIRE-URL --query value -o tsv)
+            echo "::add-mask::$ISPYFIRE_URL"
+            echo "ISPYFIRE_URL=$ISPYFIRE_URL" >> $GITHUB_ENV
+
+            ISPYFIRE_USERNAME=$(az keyvault secret show --vault-name gh-website-utilities --name ISPYFIRE-USERNAME --query value -o tsv)
+            echo "::add-mask::$ISPYFIRE_USERNAME"
+            echo "ISPYFIRE_USERNAME=$ISPYFIRE_USERNAME" >> $GITHUB_ENV
+
+            ISPYFIRE_PASSWORD=$(az keyvault secret show --vault-name gh-website-utilities --name ISPYFIRE-PASSWORD --query value -o tsv)
+            echo "::add-mask::$ISPYFIRE_PASSWORD"
+            echo "ISPYFIRE_PASSWORD=$ISPYFIRE_PASSWORD" >> $GITHUB_ENV
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Summary
Prevent secrets from appearing in GitHub Actions logs by masking them before adding to `$GITHUB_ENV`.

## Problem
When fetching secrets from Azure Key Vault using the inline echo pattern, the secret values were being printed to the workflow logs.

## Solution
Use GitHub's `::add-mask::` workflow command to mask each secret value before adding it to the environment:

```bash
SECRET=$(az keyvault secret show ... --query value -o tsv)
echo "::add-mask::$SECRET"
echo "SECRET=$SECRET" >> $GITHUB_ENV
```

## Files Changed
- `.github/workflows/entra-sync.yml` - Mask all Aladtec and MS Graph secrets
- `.github/workflows/ispyfire-sync.yml` - Mask all MS Graph and iSpyFire secrets