### PR TITLE
Standardize marine positions with namespace prefix, add additional position

### DIFF
--- a/src/sjifire/core/constants.py
+++ b/src/sjifire/core/constants.py
@@ -11,8 +11,9 @@ RANK_HIERARCHY: list[str] = [
 
 # Marine positions (boat crew)
 MARINE_POSITIONS: set[str] = {
-    "Mate",
-    "Pilot",
+    "Marine: Deckhand",
+    "Marine: Mate",
+    "Marine: Pilot",
 }
 
 # Operational positions that indicate active response/support roles

--- a/src/sjifire/entra/group_sync.py
+++ b/src/sjifire/entra/group_sync.py
@@ -320,7 +320,7 @@ class WildlandFirefighterGroupStrategy(GroupSyncStrategy):
 class MarineGroupStrategy(GroupSyncStrategy):
     """Sync strategy for Marine group.
 
-    Creates a Marine M365 group containing members with Mate or Pilot positions.
+    Creates a Marine M365 group containing members with marine positions.
     """
 
     @property
@@ -332,12 +332,12 @@ class MarineGroupStrategy(GroupSyncStrategy):
     def automation_notice(self) -> str:
         """Return automation notice for marine group."""
         return (
-            "⚠️ Membership is automatically managed based on Mate/Pilot positions "
+            "⚠️ Membership is automatically managed based on Marine positions "
             "in Aladtec. Manual changes will be overwritten."
         )
 
     def get_groups_to_sync(self, members: list[Member]) -> dict[str, list[Member]]:
-        """Get members with marine positions (Mate or Pilot)."""
+        """Get members with marine positions."""
         marine_members = [m for m in members if set(m.positions or []) & MARINE_POSITIONS]
         if marine_members:
             return {"Marine": marine_members}
@@ -348,7 +348,7 @@ class MarineGroupStrategy(GroupSyncStrategy):
         return (
             "Marine",
             "marine",
-            "Members with Mate or Pilot positions",
+            "Members with Marine positions",
         )
 
 

--- a/tests/test_station_groups.py
+++ b/tests/test_station_groups.py
@@ -362,13 +362,13 @@ class TestMarineGroupStrategy:
     def test_automation_notice(self):
         notice = self.strategy.automation_notice
         assert "automatically" in notice.lower()
-        assert "Mate" in notice or "Pilot" in notice
+        assert "Marine" in notice
 
     def test_get_group_config(self):
         display_name, mail_nickname, description = self.strategy.get_group_config("Marine")
         assert display_name == "Marine"
         assert mail_nickname == "marine"
-        assert "Mate" in description or "Pilot" in description
+        assert "Marine" in description
 
     def test_get_groups_to_sync_empty(self):
         assert self.strategy.get_groups_to_sync([]) == {}
@@ -378,7 +378,7 @@ class TestMarineGroupStrategy:
             id="1",
             first_name="John",
             last_name="Doe",
-            positions=["Mate"],
+            positions=["Marine: Mate"],
         )
         result = self.strategy.get_groups_to_sync([member])
         assert "Marine" in result
@@ -389,18 +389,29 @@ class TestMarineGroupStrategy:
             id="1",
             first_name="John",
             last_name="Doe",
-            positions=["Pilot"],
+            positions=["Marine: Pilot"],
         )
         result = self.strategy.get_groups_to_sync([member])
         assert "Marine" in result
         assert len(result["Marine"]) == 1
 
-    def test_get_groups_to_sync_both_positions(self):
+    def test_get_groups_to_sync_deckhand_position(self):
         member = Member(
             id="1",
             first_name="John",
             last_name="Doe",
-            positions=["Mate", "Pilot"],
+            positions=["Marine: Deckhand"],
+        )
+        result = self.strategy.get_groups_to_sync([member])
+        assert "Marine" in result
+        assert len(result["Marine"]) == 1
+
+    def test_get_groups_to_sync_multiple_marine_positions(self):
+        member = Member(
+            id="1",
+            first_name="John",
+            last_name="Doe",
+            positions=["Marine: Mate", "Marine: Pilot"],
         )
         result = self.strategy.get_groups_to_sync([member])
         assert "Marine" in result
@@ -418,8 +429,8 @@ class TestMarineGroupStrategy:
 
     def test_get_groups_to_sync_multiple_members(self):
         members = [
-            Member(id="1", first_name="John", last_name="Doe", positions=["Mate"]),
-            Member(id="2", first_name="Jane", last_name="Smith", positions=["Pilot"]),
+            Member(id="1", first_name="John", last_name="Doe", positions=["Marine: Mate"]),
+            Member(id="2", first_name="Jane", last_name="Smith", positions=["Marine: Pilot"]),
             Member(id="3", first_name="Bob", last_name="Wilson", positions=["Firefighter"]),
         ]
         result = self.strategy.get_groups_to_sync(members)
@@ -428,7 +439,7 @@ class TestMarineGroupStrategy:
 
     def test_marine_positions_include_all_expected(self):
         """Verify all expected marine positions are configured."""
-        expected = {"Mate", "Pilot"}
+        expected = {"Marine: Deckhand", "Marine: Mate", "Marine: Pilot"}
         assert expected == MARINE_POSITIONS
 
 
@@ -543,8 +554,9 @@ class TestVolunteerGroupStrategy:
             "Firefighter",
             "Apparatus Operator",
             "Support",
-            "Mate",
-            "Pilot",
+            "Marine: Deckhand",
+            "Marine: Mate",
+            "Marine: Pilot",
             "Wildland Firefighter",
         }
         assert expected == OPERATIONAL_POSITIONS


### PR DESCRIPTION
## Summary
This PR standardizes marine position naming by adding a "Marine: " namespace prefix to all marine-related positions and adds a new "Marine: Deckhand" position. This improves consistency with position naming conventions and makes the position hierarchy clearer.

## Key Changes
- Updated `MARINE_POSITIONS` constant to include three positions with "Marine: " prefix:
  - "Marine: Deckhand" (new)
  - "Marine: Mate"
  - "Marine: Pilot"
- Updated `MarineGroupStrategy` documentation and automation notices to reference "marine positions" generically instead of listing specific position names
- Updated all test cases to use the new namespaced position names
- Updated `OPERATIONAL_POSITIONS` constant to reflect the new marine position names
