### PR TITLE
Include deleted users in iSpyFire sync to prevent duplicates

### DIFF
--- a/src/sjifire/scripts/ispyfire_sync.py
+++ b/src/sjifire/scripts/ispyfire_sync.py
@@ -195,10 +195,10 @@ async def run_sync(dry_run: bool = True, single_email: str | None = None) -> int
             return 1
         logger.info(f"Filtering to single user: {single_email}")
 
-    # Get iSpyFire people (include inactive to detect manual deactivations)
+    # Get iSpyFire people (include inactive and deleted to prevent duplicates)
     logger.info("Fetching iSpyFire people...")
     with ISpyFireClient() as ispy_client:
-        ispyfire_people = ispy_client.get_people(include_inactive=True)
+        ispyfire_people = ispy_client.get_people(include_inactive=True, include_deleted=True)
 
         # Backup current state (only for full sync)
         if ispyfire_people and not single_email:


### PR DESCRIPTION
## Summary
- Include soft-deleted users when fetching iSpyFire people for comparison
- Prevents creating duplicate entries when a user was previously deleted

## Problem
Robin Garcia was soft-deleted in iSpyFire. When the sync ran, it didn't see her (only checked inactive, not deleted) and created a duplicate entry.

## Solution
Change `get_people(include_inactive=True)` to `get_people(include_inactive=True, include_deleted=True)`

The existing reactivation logic (lines 253-262) will automatically reactivate matched users who are inactive/deleted.

## Test plan
- [x] All 121 iSpyFire tests pass
- [x] Verify no duplicates created on next sync