### PR TITLE
Add additional Entra ID sync schedules throughout the day

### DIFF
--- a/.github/workflows/entra-sync.yml
+++ b/.github/workflows/entra-sync.yml
@@ -2,8 +2,16 @@ name: Entra ID Sync
 
 on:
   schedule:
+    # Run at 8am Pacific, Monday-Friday (16:00 UTC = 8am PST / 9am PDT)
+    - cron: '0 16 * * 1-5'
     # Run at noon Pacific, Monday-Friday (20:00 UTC = 12pm PST / 1pm PDT)
     - cron: '0 20 * * 1-5'
+    # Run at 6pm Pacific, Monday-Friday (02:00 UTC next day = 6pm PST / 7pm PDT)
+    - cron: '0 2 * * 2-6'
+    # Run at noon Pacific, Saturday (20:00 UTC = 12pm PST / 1pm PDT)
+    - cron: '0 20 * * 6'
+    # Run at noon Pacific, Sunday (20:00 UTC = 12pm PST / 1pm PDT)
+    - cron: '0 20 * * 0'
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
## Summary
Extended the Entra ID sync workflow to run more frequently throughout the day and on weekends, ensuring more up-to-date user and group synchronization.

## Changes
- Added 8am Pacific (16:00 UTC) sync on weekdays (Monday-Friday)
- Added 6pm Pacific (02:00 UTC next day) sync on weekdays (Tuesday-Saturday)
- Added noon Pacific (20:00 UTC) sync on Saturday
- Added noon Pacific (20:00 UTC) sync on Sunday
- Retained existing noon Pacific (20:00 UTC) sync on weekdays

## Details
The workflow now runs on a more comprehensive schedule:
- **Weekdays**: 8am, noon, and 6pm Pacific
- **Saturday**: Noon Pacific
- **Sunday**: Noon Pacific

This ensures Entra ID changes are synchronized multiple times daily on business days and at least once daily on weekends, reducing the window for out-of-sync user and group data.

https://claude.ai/code/session_01RL6zWneHAVzm9UY5jLg2HW