### PR TITLE
Shorten replay cycle to 105s to minimize idle gap

### DIFF
--- a/src/sjifire/ops/kiosk/replay_data.py
+++ b/src/sjifire/ops/kiosk/replay_data.py
@@ -35,7 +35,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 # Cycle length in seconds before the scenario restarts
-CYCLE_SECONDS = 120
+# Call is active T+5 to T+100, then ~5s idle before the next loop.
+CYCLE_SECONDS = 105
 
 # Module-level caches
 _fixture_detail: dict | None = None


### PR DESCRIPTION
## Summary
- Reduces `CYCLE_SECONDS` from 120 to 105
- Call is active T+5 to T+100, then ~5s idle before the next loop (was 20s)

## Test plan
- [x] All 1716 tests pass
- [x] Deployed and verified on ops.sjifire.org