### PR TITLE
Replace kiosk in-memory archival with Cosmos DB query

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,20 @@ SJI Fire District utilities for syncing personnel data between Aladtec (scheduli
 - **ruff** for linting/formatting
 - **ty** for type checking
 
+## Stateless Containers — CRITICAL Architecture Rule
+
+The ops server runs on Azure Container Apps with **0-many replicas** that restart at any time (deploys, scaling, platform maintenance). Every replica must function identically from a cold start.
+
+**In-memory module-level state is ephemeral.** It will be lost on restart and is NOT shared across replicas.
+
+| OK | NOT OK |
+|---|---|
+| Short-lived TTL caches (seconds) that reduce redundant API calls. Rebuilt automatically on the next request. | Tracking state transitions between requests (e.g., "call was open, now it's gone → archive it"). |
+| Locks to prevent concurrent fetches within one process. | Accumulating data over time in dicts/lists that grow across requests. |
+| Static config loaded once at startup. | Any data that must survive a restart or be visible to other replicas. |
+
+**If it needs to survive a restart, it goes to Cosmos DB.** No exceptions. The `dispatch-sync` background task already stores completed calls, schedules are cached in Cosmos, and incidents are in Cosmos. Query those stores instead of trying to reconstruct state in memory.
+
 ## Key Concepts
 
 ### Aladtec

--- a/src/sjifire/ops/dashboard.py
+++ b/src/sjifire/ops/dashboard.py
@@ -90,11 +90,13 @@ def _get_section_labels() -> dict[str, str]:
 # Both the nav bar (/api/open-calls) and the kiosk (/kiosk/data) read from
 # this cache.  Only ONE iSpyFire poll happens per TTL period regardless of
 # how many consumers request data.
+#
+# Ephemeral TTL caches only — see "Stateless Containers" in CLAUDE.md.
 
 _open_docs_cache: list | None = None  # list[DispatchCallDocument] | None
 _open_docs_ts: float = 0
 _open_docs_lock = asyncio.Lock()
-_call_first_seen: dict[str, float] = {}  # dispatch_id -> monotonic timestamp
+_call_first_seen: dict[str, float] = {}  # dispatch_id -> monotonic ts (adaptive TTL only)
 
 
 def _open_calls_ttl() -> float:
@@ -648,18 +650,10 @@ async def render_kiosk() -> str:
 # ---------------------------------------------------------------------------
 # Kiosk data — adaptive caching for open calls + crew
 # ---------------------------------------------------------------------------
+#
+# Ephemeral TTL cache only — see "Stateless Containers" in CLAUDE.md.
+# Durable data (completed calls, schedule) comes from Cosmos DB.
 
-# Track when each call was first seen (call_id -> monotonic timestamp)
-_kiosk_call_first_seen: dict[str, float] = {}
-
-# Recently-completed calls kept on kiosk in "archived" mode.
-# Maps dispatch_id -> {"data": <enriched call dict>, "completed_at": <ISO str>}
-_kiosk_archived_calls: dict[str, dict] = {}
-
-# Default hours to keep archived calls on the kiosk display.
-_KIOSK_ARCHIVE_HOURS = 12
-
-# Kiosk cache (enriched calls + crew + schedule)
 _kiosk_cache: dict | None = None
 _kiosk_cache_ts: float = 0
 _kiosk_cache_lock = asyncio.Lock()
@@ -691,22 +685,59 @@ async def get_kiosk_data() -> dict:
         return result
 
 
-def _find_previous_call(dispatch_id: str) -> dict | None:
-    """Find a call's enriched data from the last kiosk cache snapshot."""
-    if _kiosk_cache is None:
-        return None
-    for call in _kiosk_cache.get("calls", []):
-        if call.get("dispatch_id") == dispatch_id and not call.get("archived"):
-            # Deep copy so archived snapshot is independent of future cache updates
-            return dict(call)
-    return None
+async def _fetch_recently_completed(*, hours: int = 12) -> list[dict]:
+    """Fetch recently completed calls from Cosmos DB for kiosk display.
+
+    Returns enriched dicts matching the kiosk frontend contract
+    (``archived=True``, ``completed_at`` as ISO string).
+
+    Args:
+        hours: How far back to look for completed calls.
+    """
+    cutoff = datetime.now(UTC) - timedelta(hours=hours)
+
+    async with DispatchStore() as store:
+        docs = await store.list_recent(limit=20)
+
+    results = []
+    for doc in docs:
+        if not doc.is_completed:
+            continue
+        if doc.stored_at < cutoff:
+            continue
+
+        # Parse geo_location into lat/lon
+        lat, lon = None, None
+        geo = doc.geo_location or ""
+        if geo:
+            parts = geo.replace(" ", "").split(",")
+            if len(parts) == 2:
+                with contextlib.suppress(ValueError):
+                    lat, lon = float(parts[0]), float(parts[1])
+
+        results.append(
+            {
+                "dispatch_id": doc.long_term_call_id,
+                "nature": doc.nature,
+                "address": doc.address,
+                "severity": _get_severity(doc.nature),
+                "icon": _get_icon(doc.nature),
+                "latitude": lat,
+                "longitude": lon,
+                "archived": True,
+                "completed_at": doc.stored_at.isoformat(),
+            }
+        )
+
+    return results
 
 
 async def _fetch_kiosk_data() -> dict:
-    """Fetch open calls (enriched) and schedule in parallel."""
-    open_calls_result, schedule_result = await asyncio.gather(
+    """Fetch open calls (enriched), recently completed, and schedule."""
+    open_calls_result, schedule_result, archived_result = await asyncio.gather(
         _fetch_open_calls_enriched(),
         _fetch_schedule_for_kiosk(),
+        _fetch_recently_completed(),
         return_exceptions=True,
     )
 
@@ -719,53 +750,13 @@ async def _fetch_kiosk_data() -> dict:
     else:
         result["calls"] = open_calls_result
 
-    # Update first-seen tracking and detect newly-completed calls
-    active_calls = [c for c in result["calls"] if not c.get("archived")]
-    current_ids = {c["dispatch_id"] for c in active_calls}
-    now_mono = time.monotonic()
-    now_utc = datetime.now(UTC)
+    # Append archived calls from Cosmos DB (recently completed)
+    if isinstance(archived_result, BaseException):
+        logger.warning("Kiosk: recently completed fetch failed: %s", archived_result)
+    elif not result["calls"]:
+        # No active calls — show recently completed
+        result["calls"].extend(archived_result)
 
-    # Archive calls that just disappeared from the open list
-    for old_id in list(_kiosk_call_first_seen):
-        if old_id not in current_ids:
-            # Look up the last known enriched data from the previous cache
-            prev_call = _find_previous_call(old_id)
-            if prev_call:
-                prev_call["archived"] = True
-                prev_call["completed_at"] = now_utc.isoformat()
-                _kiosk_archived_calls[old_id] = {
-                    "data": prev_call,
-                    "completed_at": now_utc.isoformat(),
-                    "mono_ts": now_mono,
-                }
-                logger.info("Kiosk: archived completed call %s", old_id)
-            del _kiosk_call_first_seen[old_id]
-
-    for call_id in current_ids:
-        if call_id not in _kiosk_call_first_seen:
-            _kiosk_call_first_seen[call_id] = now_mono
-
-    # Determine archive window
-    archive_seconds = _KIOSK_ARCHIVE_HOURS * 3600
-
-    # Option A: any active call clears all archived calls
-    if current_ids and _kiosk_archived_calls:
-        logger.info(
-            "Kiosk: clearing %d archived call(s) — active call present",
-            len(_kiosk_archived_calls),
-        )
-        _kiosk_archived_calls.clear()
-
-    # Time-based expiry for archived calls (when no active calls)
-    for aid in list(_kiosk_archived_calls):
-        entry = _kiosk_archived_calls[aid]
-        if (now_mono - entry["mono_ts"]) > archive_seconds:
-            logger.info("Kiosk: expired archived call %s (age > %dh)", aid, _KIOSK_ARCHIVE_HOURS)
-            del _kiosk_archived_calls[aid]
-
-    # Append archived calls to the response (after active calls)
-    for entry in _kiosk_archived_calls.values():
-        result["calls"].append(entry["data"])
     # Schedule
     if isinstance(schedule_result, BaseException):
         logger.exception("Kiosk: schedule fetch failed", exc_info=schedule_result)

--- a/tests/ops/test_dashboard.py
+++ b/tests/ops/test_dashboard.py
@@ -2,7 +2,7 @@
 
 import os
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -15,9 +15,6 @@ from sjifire.ops.dashboard import (
     _fetch_kiosk_data,
     _fetch_open_docs_cached,
     _fetch_recent_calls,
-    _find_previous_call,
-    _kiosk_archived_calls,
-    _kiosk_call_first_seen,
     _normalize_incident_number,
     _open_calls_ttl,
     get_dashboard,
@@ -1074,16 +1071,12 @@ def _reset_open_calls_cache():
     dashboard_mod._kiosk_cache = None
     dashboard_mod._kiosk_cache_ts = 0
     _call_first_seen.clear()
-    _kiosk_call_first_seen.clear()
-    _kiosk_archived_calls.clear()
     yield
     dashboard_mod._open_docs_cache = None
     dashboard_mod._open_docs_ts = 0
     dashboard_mod._kiosk_cache = None
     dashboard_mod._kiosk_cache_ts = 0
     _call_first_seen.clear()
-    _kiosk_call_first_seen.clear()
-    _kiosk_archived_calls.clear()
 
 
 class TestOpenCallsTTL:
@@ -1266,180 +1259,133 @@ class TestGetOpenCallsCached:
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: kiosk archived calls
+# Unit tests: kiosk recently completed (Cosmos DB)
 # ---------------------------------------------------------------------------
 
 
-def _make_enriched_call(dispatch_id: str, **overrides) -> dict:
-    """Build a minimal enriched call dict for kiosk tests."""
-    call = {
-        "dispatch_id": dispatch_id,
-        "nature": "Fire Alarm",
-        "address": "100 Guard St",
-        "severity": "high",
-    }
-    call.update(overrides)
-    return call
-
-
-class TestFindPreviousCall:
-    """Unit tests for _find_previous_call cache lookup."""
-
-    def test_returns_none_when_no_cache(self):
-        dashboard_mod._kiosk_cache = None
-        assert _find_previous_call("26-001234") is None
-
-    def test_finds_call_in_cache(self):
-        call = _make_enriched_call("26-001234")
-        dashboard_mod._kiosk_cache = {"calls": [call]}
-        result = _find_previous_call("26-001234")
-        assert result is not None
-        assert result["dispatch_id"] == "26-001234"
-
-    def test_returns_copy_not_reference(self):
-        call = _make_enriched_call("26-001234")
-        dashboard_mod._kiosk_cache = {"calls": [call]}
-        result = _find_previous_call("26-001234")
-        result["extra"] = "modified"
-        assert "extra" not in call
-
-    def test_skips_archived_calls(self):
-        call = _make_enriched_call("26-001234", archived=True)
-        dashboard_mod._kiosk_cache = {"calls": [call]}
-        assert _find_previous_call("26-001234") is None
-
-    def test_returns_none_for_missing_id(self):
-        call = _make_enriched_call("26-001234")
-        dashboard_mod._kiosk_cache = {"calls": [call]}
-        assert _find_previous_call("26-999999") is None
-
-
-class TestKioskArchivedCalls:
-    """Unit tests for kiosk call archival in _fetch_kiosk_data."""
+class TestKioskRecentlyCompleted:
+    """Unit tests for kiosk archived calls sourced from Cosmos DB."""
 
     @patch("sjifire.ops.dashboard._fetch_schedule_for_kiosk", new_callable=AsyncMock)
     @patch("sjifire.ops.dashboard._fetch_open_calls_enriched", new_callable=AsyncMock)
-    async def test_call_disappearing_gets_archived(self, mock_open, mock_schedule):
-        """A call present in first fetch but absent in second gets archived."""
-        call = _make_enriched_call("26-001234")
+    async def test_completed_call_appears_as_archived(self, mock_open, mock_schedule):
+        """A completed call from Cosmos appears with archived=True when no active calls."""
         mock_schedule.return_value = {"crew": [], "platoon": "A"}
-
-        # First fetch: call is active
-        mock_open.return_value = [call]
-        result1 = await _fetch_kiosk_data()
-        assert len(result1["calls"]) == 1
-        assert "26-001234" in _kiosk_call_first_seen
-
-        # Simulate get_kiosk_data() caching the result (so _find_previous_call works)
-        dashboard_mod._kiosk_cache = result1
-
-        # Second fetch: call gone — should be archived
         mock_open.return_value = []
-        result2 = await _fetch_kiosk_data()
 
-        assert "26-001234" not in _kiosk_call_first_seen
-        assert "26-001234" in _kiosk_archived_calls
-        # Archived call appears in response
-        archived = [c for c in result2["calls"] if c.get("archived")]
+        now = datetime.now(UTC)
+
+        # Store a recently completed call in the in-memory dispatch store
+        doc = DispatchCallDocument(
+            id="call-archived",
+            year="2026",
+            long_term_call_id="26-002000",
+            nature="Fire Alarm",
+            address="100 Guard St",
+            agency_code="SJF",
+            time_reported=now - timedelta(hours=3),
+            is_completed=True,
+            stored_at=now - timedelta(hours=2),
+        )
+        async with DispatchStore() as store:
+            await store.upsert(doc)
+
+        result = await _fetch_kiosk_data()
+
+        archived = [c for c in result["calls"] if c.get("archived")]
         assert len(archived) == 1
-        assert archived[0]["dispatch_id"] == "26-001234"
+        assert archived[0]["dispatch_id"] == "26-002000"
+        assert archived[0]["nature"] == "Fire Alarm"
+        assert archived[0]["archived"] is True
         assert "completed_at" in archived[0]
 
     @patch("sjifire.ops.dashboard._fetch_schedule_for_kiosk", new_callable=AsyncMock)
     @patch("sjifire.ops.dashboard._fetch_open_calls_enriched", new_callable=AsyncMock)
-    async def test_new_active_call_clears_archive(self, mock_open, mock_schedule):
-        """A new active call appearing clears all archived calls."""
+    async def test_active_call_excludes_archived(self, mock_open, mock_schedule):
+        """When an active call is present, archived calls are not shown."""
         mock_schedule.return_value = {"crew": [], "platoon": "A"}
+        mock_open.return_value = [
+            {
+                "dispatch_id": "26-ACTIVE",
+                "nature": "Medical Aid",
+                "address": "200 Spring St",
+                "severity": "low",
+                "icon": "\U0001f4df",
+            }
+        ]
 
-        # Seed an archived call
-        _kiosk_archived_calls["26-OLD"] = {
-            "data": _make_enriched_call(
-                "26-OLD", archived=True, completed_at="2026-02-17T10:00:00"
-            ),
-            "completed_at": "2026-02-17T10:00:00",
-            "mono_ts": time.monotonic() - 60,
-        }
+        now = datetime.now(UTC)
 
-        # New active call arrives
-        mock_open.return_value = [_make_enriched_call("26-NEW")]
+        # Store a recently completed call
+        doc = DispatchCallDocument(
+            id="call-archived",
+            year="2026",
+            long_term_call_id="26-002000",
+            nature="Fire Alarm",
+            address="100 Guard St",
+            agency_code="SJF",
+            time_reported=now - timedelta(hours=3),
+            is_completed=True,
+            stored_at=now - timedelta(hours=2),
+        )
+        async with DispatchStore() as store:
+            await store.upsert(doc)
+
         result = await _fetch_kiosk_data()
 
-        # Archive cleared because an active call is present
-        assert len(_kiosk_archived_calls) == 0
-        # Only the active call in response
+        # Only the active call, no archived
         assert len(result["calls"]) == 1
-        assert result["calls"][0]["dispatch_id"] == "26-NEW"
+        assert result["calls"][0]["dispatch_id"] == "26-ACTIVE"
 
     @patch("sjifire.ops.dashboard._fetch_schedule_for_kiosk", new_callable=AsyncMock)
     @patch("sjifire.ops.dashboard._fetch_open_calls_enriched", new_callable=AsyncMock)
-    async def test_archived_call_expires_after_window(self, mock_open, mock_schedule):
-        """Archived calls are removed after _KIOSK_ARCHIVE_HOURS."""
+    async def test_old_completed_call_excluded(self, mock_open, mock_schedule):
+        """A call completed more than 12 hours ago is not shown."""
         mock_schedule.return_value = {"crew": [], "platoon": "A"}
-
-        # Seed an archived call that's older than the expiry window
-        expired_ts = time.monotonic() - (dashboard_mod._KIOSK_ARCHIVE_HOURS * 3600 + 1)
-        _kiosk_archived_calls["26-EXPIRED"] = {
-            "data": _make_enriched_call("26-EXPIRED", archived=True),
-            "completed_at": "2026-02-16T10:00:00",
-            "mono_ts": expired_ts,
-        }
-
         mock_open.return_value = []
+
+        # Store a call with stored_at >12h ago
+        doc = DispatchCallDocument(
+            id="call-old",
+            year="2026",
+            long_term_call_id="26-001500",
+            nature="Medical Aid",
+            address="200 Spring St",
+            agency_code="SJF",
+            time_reported=datetime(2026, 2, 16, 10, 0, tzinfo=UTC),
+            is_completed=True,
+            stored_at=datetime(2026, 2, 16, 10, 30, tzinfo=UTC),
+        )
+        async with DispatchStore() as store:
+            await store.upsert(doc)
+
         result = await _fetch_kiosk_data()
 
-        assert "26-EXPIRED" not in _kiosk_archived_calls
         assert len(result["calls"]) == 0
 
     @patch("sjifire.ops.dashboard._fetch_schedule_for_kiosk", new_callable=AsyncMock)
     @patch("sjifire.ops.dashboard._fetch_open_calls_enriched", new_callable=AsyncMock)
-    async def test_archived_call_survives_within_window(self, mock_open, mock_schedule):
-        """Archived calls persist when within the expiry window and no active calls."""
+    async def test_open_call_in_cosmos_not_duplicated(self, mock_open, mock_schedule):
+        """A call that's both open and in Cosmos is not duplicated as archived."""
         mock_schedule.return_value = {"crew": [], "platoon": "A"}
-
-        recent_ts = time.monotonic() - 300  # 5 minutes ago
-        _kiosk_archived_calls["26-RECENT"] = {
-            "data": _make_enriched_call(
-                "26-RECENT", archived=True, completed_at="2026-02-17T17:00:00"
-            ),
-            "completed_at": "2026-02-17T17:00:00",
-            "mono_ts": recent_ts,
-        }
-
         mock_open.return_value = []
+
+        # Store an open (not completed) call in Cosmos
+        doc = DispatchCallDocument(
+            id="call-open",
+            year="2026",
+            long_term_call_id="26-003000",
+            nature="Fire Alarm",
+            address="100 Guard St",
+            agency_code="SJF",
+            time_reported=datetime(2026, 2, 17, 15, 0, tzinfo=UTC),
+            is_completed=False,
+            stored_at=datetime(2026, 2, 17, 15, 0, tzinfo=UTC),
+        )
+        async with DispatchStore() as store:
+            await store.upsert(doc)
+
         result = await _fetch_kiosk_data()
 
-        assert "26-RECENT" in _kiosk_archived_calls
-        archived = [c for c in result["calls"] if c.get("archived")]
-        assert len(archived) == 1
-
-    @patch("sjifire.ops.dashboard._fetch_schedule_for_kiosk", new_callable=AsyncMock)
-    @patch("sjifire.ops.dashboard._fetch_open_calls_enriched", new_callable=AsyncMock)
-    async def test_first_seen_tracks_new_calls(self, mock_open, mock_schedule):
-        """New calls get added to _kiosk_call_first_seen."""
-        mock_schedule.return_value = {"crew": [], "platoon": "A"}
-        mock_open.return_value = [
-            _make_enriched_call("26-AAA"),
-            _make_enriched_call("26-BBB"),
-        ]
-
-        await _fetch_kiosk_data()
-
-        assert "26-AAA" in _kiosk_call_first_seen
-        assert "26-BBB" in _kiosk_call_first_seen
-
-    @patch("sjifire.ops.dashboard._fetch_schedule_for_kiosk", new_callable=AsyncMock)
-    @patch("sjifire.ops.dashboard._fetch_open_calls_enriched", new_callable=AsyncMock)
-    async def test_call_without_previous_cache_not_archived(self, mock_open, mock_schedule):
-        """A call that disappears but has no previous cache entry is not archived."""
-        mock_schedule.return_value = {"crew": [], "platoon": "A"}
-
-        # Seed first_seen but no kiosk_cache (so _find_previous_call returns None)
-        _kiosk_call_first_seen["26-NOCACHE"] = time.monotonic()
-        dashboard_mod._kiosk_cache = None
-
-        mock_open.return_value = []
-        await _fetch_kiosk_data()
-
-        # Removed from first_seen but NOT added to archived (no previous data)
-        assert "26-NOCACHE" not in _kiosk_call_first_seen
-        assert "26-NOCACHE" not in _kiosk_archived_calls
+        # Open (not completed) calls are excluded from archived
+        assert len(result["calls"]) == 0


### PR DESCRIPTION
## Summary
- Removes in-memory call archival (`_kiosk_archived_calls`, `_kiosk_call_first_seen`, `_find_previous_call`) which missed calls when the container restarted between open→closed transitions (e.g. today's 10am fire alarm)
- Adds `_fetch_recently_completed()` that queries completed calls from Cosmos DB (populated by `dispatch-sync` background task) within the last 12 hours
- Same frontend behavior: `archived=True` + `completed_at` on each call, active calls suppress archived display

## Test plan
- [x] `uv run pytest tests/ops/test_dashboard.py -v` — 48 passed
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Deploy → visit kiosk → completed calls from last 12h show with COMPLETED badge even on fresh container start