### PR TITLE
Polish pagination and assistant drawer UX

### DIFF
--- a/src/sjifire/ops/templates/dashboard.html
+++ b/src/sjifire/ops/templates/dashboard.html
@@ -26,7 +26,7 @@
 
     /* Content wrapper */
     .content-wrap { max-width: 1200px; margin: 0 auto; }
-    .content-wrap.reports-active { max-width: none; }
+    /* (reports tab now uses same max-width as other tabs) */
 
     /* ── Grid layouts ── */
     .grid-4, .grid-3, .grid-overview { display: grid; gap: 16px; }
@@ -105,9 +105,7 @@
     .completeness-bar .bar-fill { display: block; height: 100%; background: var(--color-blue); border-radius: 3px; }
 
     /* ── Reports layout ── */
-    .reports-layout {
-      max-width: none;
-    }
+    .reports-layout {}
 
     /* Table hover */
     .data-table tbody tr { transition: background .15s; }
@@ -587,7 +585,7 @@
 {% endblock %}
 
 {% block body %}
-<main class="content-wrap dashboard-main" :style="activeTab === 'reports' ? 'padding:12px 12px 24px' : 'padding:24px'" :class="{'reports-active': activeTab === 'reports'}">
+<main class="content-wrap dashboard-main" style="padding:24px">
 
   <!-- LOADING SKELETON -->
   <div x-show="loading">


### PR DESCRIPTION
## Summary
- **Pagination**: Moved inside the panel container with a border-top separator, replaced reused `action-btn edit` styling with dedicated ghost-style `page-btn` buttons (blue hover), switched to lighter single-chevron arrows
- **Assistant drawer**: Clicking the toggle now expands even when empty — shows a welcome message and 6 action hint chips instead of doing nothing. Inline bar hints auto-hide when drawer is open to avoid duplication.

## Test plan
- [x] Verify pagination renders inside the table panel with a subtle top border
- [x] Verify prev/next buttons use ghost styling (outline, blue on hover)
- [x] Verify disabled state on first/last page
- [x] Click Assistant toggle with no messages — should expand with welcome text and 6 hint chips
- [x] Click a hint chip — should send the message and switch to messages view
- [x] Verify inline bar hints hide when drawer is expanded, reappear when collapsed