### PR TITLE
Fix NERIS update ignoring staffing and response_mode changes

### DIFF
--- a/src/sjifire/ops/incidents/neris.py
+++ b/src/sjifire/ops/incidents/neris.py
@@ -1078,42 +1078,65 @@ def _build_neris_diff(doc: IncidentDocument, neris_record: dict) -> dict:
             diff["timestamps"]["local"][local_key] = local_val
             diff["timestamps"]["neris"][neris_key] = neris_val
 
-    # Unit-level timestamps
+    # ── Unit-level fields ──
+    # Each entry: (local_field, neris_field, type) where type controls
+    # comparison and serialization:
+    #   "ts"  — ISO timestamp (compared with _timestamps_equal, serialized via to_utc_iso)
+    #   "str" — plain string (compared case-sensitive, passed through as-is)
+    unit_field_map: list[tuple[str, str, str]] = [
+        ("dispatch", "dispatch", "ts"),
+        ("enroute", "enroute_to_scene", "ts"),
+        ("staged", "staging", "ts"),
+        ("on_scene", "on_scene", "ts"),
+        ("cleared", "unit_clear", "ts"),
+        ("canceled", "canceled_enroute", "ts"),
+        ("response_mode", "response_mode", "str"),
+    ]
+
     neris_units = dispatch.get("unit_responses") or []
-    # Key by uppercase for case-insensitive matching; store NERIS reported_unit_id
     neris_unit_map_local: dict[str, dict] = {}
     for nu in neris_units:
         uid = nu.get("reported_unit_id") or _resolve_neris_unit_id(nu.get("unit_neris_id", ""))
         if uid:
             neris_unit_map_local[uid.upper()] = nu
 
-    field_map = {
-        "dispatch": "dispatch",
-        "enroute": "enroute_to_scene",
-        "staged": "staging",
-        "on_scene": "on_scene",
-        "cleared": "unit_clear",
-        "canceled": "canceled_enroute",
-    }
     for unit in doc.units:
         neris_unit = neris_unit_map_local.get(unit.unit_id.upper(), {})
-        neris_uid = neris_unit.get("neris_uid")  # NERIS internal ID for patching
+        neris_uid = neris_unit.get("neris_uid")
         neris_reported_id = neris_unit.get("reported_unit_id", "")
-        for local_field, neris_field in field_map.items():
+
+        # Collect changed fields for this unit: list of (local_field, local_val, neris_val)
+        changed: list[tuple[str, object, object]] = []
+
+        for local_field, neris_field, ftype in unit_field_map:
             local_val = getattr(unit, local_field, "")
             neris_val = neris_unit.get(neris_field) or ""
-            if local_val and not _timestamps_equal(local_val, neris_val):
-                diff.setdefault(
-                    "units",
-                    {"local": {}, "neris": {}, "neris_uids": {}, "reported_unit_ids": {}},
-                )
-                key = f"{unit.unit_id}.{local_field}"
-                diff["units"]["local"][key] = local_val
-                diff["units"]["neris"][key] = neris_val
-                if neris_uid is not None:
-                    diff["units"]["neris_uids"][unit.unit_id] = neris_uid
-                if neris_reported_id:
-                    diff["units"]["reported_unit_ids"][unit.unit_id] = neris_reported_id
+            if not local_val:
+                continue
+            if ftype == "ts" and _timestamps_equal(local_val, neris_val):
+                continue
+            if ftype == "str" and local_val == neris_val:
+                continue
+            changed.append((local_field, local_val, neris_val))
+
+        # Staffing: derived from personnel list length, compared to NERIS int
+        local_staffing = len(unit.personnel) if unit.personnel else None
+        neris_staffing = neris_unit.get("staffing")
+        if local_staffing and local_staffing != neris_staffing:
+            changed.append(("staffing", local_staffing, neris_staffing))
+
+        # Record all changes for this unit
+        for field, local_val, neris_val in changed:
+            diff.setdefault(
+                "units",
+                {"local": {}, "neris": {}, "neris_uids": {}, "reported_unit_ids": {}},
+            )
+            diff["units"]["local"][f"{unit.unit_id}.{field}"] = local_val
+            diff["units"]["neris"][f"{unit.unit_id}.{field}"] = neris_val
+            if neris_uid is not None:
+                diff["units"]["neris_uids"][unit.unit_id] = neris_uid
+            if neris_reported_id:
+                diff["units"]["reported_unit_ids"][unit.unit_id] = neris_reported_id
 
     # Incident type
     types = neris_record.get("incident_types") or []
@@ -1302,35 +1325,41 @@ def _build_neris_patch(diff: dict, neris_record: dict | None = None) -> dict:
         }
 
     if "units" in diff:
-        # Unit timestamps are patched via dispatch.unit_responses as a list
+        # Unit fields are patched via dispatch.unit_responses as a list
         # of PatchDispatchUnitResponseAction (existing units with neris_uid)
         # or AppendDispatchUnitResponseAction (new units not yet in NERIS).
         neris_uids = diff["units"].get("neris_uids", {})
         reported_ids = diff["units"].get("reported_unit_ids", {})
 
+        # Local field → NERIS field name mapping; fields not listed pass through as-is
+        # (e.g. "staffing" and "response_mode" use the same name in NERIS).
+        patch_field_map = {
+            "dispatch": "dispatch",
+            "enroute": "enroute_to_scene",
+            "staged": "staging",
+            "on_scene": "on_scene",
+            "cleared": "unit_clear",
+            "canceled": "canceled_enroute",
+        }
+        # Fields whose values are ISO timestamps and need UTC conversion
+        ts_fields = set(patch_field_map.values())
+
         # Group local diffs by unit_id
         per_unit: dict[str, dict] = {}
         for key, val in diff["units"]["local"].items():
             uid, field = key.rsplit(".", 1)
-            neris_field_map = {
-                "dispatch": "dispatch",
-                "enroute": "enroute_to_scene",
-                "staged": "staging",
-                "on_scene": "on_scene",
-                "cleared": "unit_clear",
-                "canceled": "canceled_enroute",
-            }
-            neris_field = neris_field_map.get(field, field)
+            neris_field = patch_field_map.get(field, field)
             per_unit.setdefault(uid, {})[neris_field] = val
 
         unit_actions: list[dict] = []
         for unit_id, fields in per_unit.items():
             neris_uid = neris_uids.get(unit_id)
             if neris_uid is not None:
-                # Existing unit — patch its timestamp fields
+                # Existing unit — patch changed fields
                 unit_props = {}
                 for field_name, field_val in fields.items():
-                    unit_props[field_name] = {"action": "set", "value": to_utc_iso(field_val)}
+                    value = to_utc_iso(field_val) if field_name in ts_fields else field_val
+                    unit_props[field_name] = {"action": "set", "value": value}
                 unit_actions.append(
                     {
                         "neris_uid": neris_uid,
@@ -1345,7 +1374,7 @@ def _build_neris_patch(diff: dict, neris_record: dict | None = None) -> dict:
                 append_id = reported_ids.get(unit_id, unit_id)
                 payload = {"reported_unit_id": append_id}
                 for k, v in fields.items():
-                    payload[k] = to_utc_iso(v)
+                    payload[k] = to_utc_iso(v) if k in ts_fields else v
                 unit_actions.append(
                     {
                         "action": "append",

--- a/tests/ops/test_update_neris.py
+++ b/tests/ops/test_update_neris.py
@@ -8,7 +8,12 @@ import pytest
 
 import sjifire.ops.auth as _auth_mod
 from sjifire.ops.auth import UserContext, set_current_user
-from sjifire.ops.incidents.models import DispatchNote, IncidentDocument, UnitAssignment
+from sjifire.ops.incidents.models import (
+    DispatchNote,
+    IncidentDocument,
+    PersonnelAssignment,
+    UnitAssignment,
+)
 from sjifire.ops.incidents.neris import (
     _build_neris_diff,
     _build_neris_patch,
@@ -213,6 +218,147 @@ class TestBuildNerisDiff:
         neris_record["dispatch"]["dispatch_incident_number"] = "26-002358"
         diff = _build_neris_diff(sample_doc, neris_record)
         assert "dispatch_incident_number" not in diff
+
+    def test_detects_staffing_diff(self, neris_record):
+        """Detect when local personnel count differs from NERIS staffing."""
+        doc = IncidentDocument(
+            id="staffing-test",
+            incident_number="26-002358",
+            incident_datetime=datetime(2026, 2, 20, tzinfo=UTC),
+            created_by="chief@sjifire.org",
+            neris_incident_id="FD53055879|26SJ0020|1770457554",
+            units=[
+                UnitAssignment(
+                    unit_id="E31",
+                    dispatch="2026-02-20T10:30:00Z",
+                    enroute="2026-02-20T10:32:00Z",
+                    on_scene="2026-02-20T10:40:00Z",
+                    cleared="2026-02-20T11:10:00Z",
+                    personnel=[
+                        PersonnelAssignment(name="Smith, John"),
+                        PersonnelAssignment(name="Doe, Jane"),
+                        PersonnelAssignment(name="Jones, Bob"),
+                        PersonnelAssignment(name="Lee, Chris"),
+                        PersonnelAssignment(name="Park, Sam"),
+                        PersonnelAssignment(name="Kim, Pat"),
+                    ],
+                ),
+            ],
+        )
+        # NERIS has staffing=4 but local has 6 personnel
+        neris_record["dispatch"]["unit_responses"][0]["staffing"] = 4
+        diff = _build_neris_diff(doc, neris_record)
+        assert "units" in diff
+        assert "E31.staffing" in diff["units"]["local"]
+        assert diff["units"]["local"]["E31.staffing"] == 6
+        assert diff["units"]["neris"]["E31.staffing"] == 4
+
+    def test_no_staffing_diff_when_matching(self, neris_record):
+        """No staffing diff when personnel count matches NERIS staffing."""
+        doc = IncidentDocument(
+            id="staffing-match",
+            incident_number="26-002358",
+            incident_datetime=datetime(2026, 2, 20, tzinfo=UTC),
+            created_by="chief@sjifire.org",
+            neris_incident_id="FD53055879|26SJ0020|1770457554",
+            units=[
+                UnitAssignment(
+                    unit_id="E31",
+                    dispatch="2026-02-20T10:30:00Z",
+                    enroute="2026-02-20T10:32:00Z",
+                    on_scene="2026-02-20T10:40:00Z",
+                    cleared="2026-02-20T11:10:00Z",
+                    personnel=[
+                        PersonnelAssignment(name="Smith, John"),
+                        PersonnelAssignment(name="Doe, Jane"),
+                        PersonnelAssignment(name="Jones, Bob"),
+                        PersonnelAssignment(name="Lee, Chris"),
+                    ],
+                ),
+            ],
+        )
+        neris_record["dispatch"]["unit_responses"][0]["staffing"] = 4
+        diff = _build_neris_diff(doc, neris_record)
+        # Timestamps all match, staffing matches — no unit diff
+        assert "E31.staffing" not in diff.get("units", {}).get("local", {})
+
+    def test_staffing_diff_when_neris_has_none(self, neris_record):
+        """Detect staffing diff when NERIS has no staffing but local has personnel."""
+        doc = IncidentDocument(
+            id="staffing-none",
+            incident_number="26-002358",
+            incident_datetime=datetime(2026, 2, 20, tzinfo=UTC),
+            created_by="chief@sjifire.org",
+            neris_incident_id="FD53055879|26SJ0020|1770457554",
+            units=[
+                UnitAssignment(
+                    unit_id="E31",
+                    dispatch="2026-02-20T10:30:00Z",
+                    enroute="2026-02-20T10:32:00Z",
+                    on_scene="2026-02-20T10:40:00Z",
+                    cleared="2026-02-20T11:10:00Z",
+                    personnel=[
+                        PersonnelAssignment(name="Smith, John"),
+                        PersonnelAssignment(name="Doe, Jane"),
+                        PersonnelAssignment(name="Jones, Bob"),
+                    ],
+                ),
+            ],
+        )
+        # NERIS has no staffing field
+        neris_record["dispatch"]["unit_responses"][0].pop("staffing", None)
+        diff = _build_neris_diff(doc, neris_record)
+        assert "E31.staffing" in diff["units"]["local"]
+        assert diff["units"]["local"]["E31.staffing"] == 3
+        assert diff["units"]["neris"]["E31.staffing"] is None
+
+    def test_detects_response_mode_diff(self, neris_record):
+        """Detect when local response_mode differs from NERIS."""
+        doc = IncidentDocument(
+            id="mode-test",
+            incident_number="26-002358",
+            incident_datetime=datetime(2026, 2, 20, tzinfo=UTC),
+            created_by="chief@sjifire.org",
+            neris_incident_id="FD53055879|26SJ0020|1770457554",
+            units=[
+                UnitAssignment(
+                    unit_id="E31",
+                    dispatch="2026-02-20T10:30:00Z",
+                    enroute="2026-02-20T10:32:00Z",
+                    on_scene="2026-02-20T10:40:00Z",
+                    cleared="2026-02-20T11:10:00Z",
+                    response_mode="EMERGENT",
+                ),
+            ],
+        )
+        neris_record["dispatch"]["unit_responses"][0]["response_mode"] = "NON_EMERGENT"
+        diff = _build_neris_diff(doc, neris_record)
+        assert "E31.response_mode" in diff["units"]["local"]
+        assert diff["units"]["local"]["E31.response_mode"] == "EMERGENT"
+        assert diff["units"]["neris"]["E31.response_mode"] == "NON_EMERGENT"
+
+    def test_no_response_mode_diff_when_matching(self, neris_record):
+        """No diff when local response_mode matches NERIS."""
+        doc = IncidentDocument(
+            id="mode-match",
+            incident_number="26-002358",
+            incident_datetime=datetime(2026, 2, 20, tzinfo=UTC),
+            created_by="chief@sjifire.org",
+            neris_incident_id="FD53055879|26SJ0020|1770457554",
+            units=[
+                UnitAssignment(
+                    unit_id="E31",
+                    dispatch="2026-02-20T10:30:00Z",
+                    enroute="2026-02-20T10:32:00Z",
+                    on_scene="2026-02-20T10:40:00Z",
+                    cleared="2026-02-20T11:10:00Z",
+                    response_mode="EMERGENT",
+                ),
+            ],
+        )
+        neris_record["dispatch"]["unit_responses"][0]["response_mode"] = "EMERGENT"
+        diff = _build_neris_diff(doc, neris_record)
+        assert "E31.response_mode" not in diff.get("units", {}).get("local", {})
 
 
 class TestTimestampsEqual:
@@ -526,6 +672,90 @@ class TestBuildNerisPatch:
             "action": "set",
             "value": "26-001913",
         }
+
+    def test_staffing_patch_existing_unit(self):
+        """Staffing change on existing unit produces a patch with integer value (not timestamp)."""
+        diff = {
+            "units": {
+                "local": {"E31.staffing": 6},
+                "neris": {"E31.staffing": 4},
+                "neris_uids": {"E31": 101},
+            }
+        }
+        result = _build_neris_patch(diff)
+        actions = result["dispatch"]["properties"]["unit_responses"]
+        assert len(actions) == 1
+        assert actions[0]["neris_uid"] == 101
+        assert actions[0]["action"] == "patch"
+        assert actions[0]["properties"]["staffing"] == {
+            "action": "set",
+            "value": 6,
+        }
+
+    def test_staffing_patch_new_unit(self):
+        """Staffing on a new unit (no neris_uid) should be included in the append payload."""
+        diff = {
+            "units": {
+                "local": {
+                    "L31.dispatch": "2026-02-20T10:31:00Z",
+                    "L31.staffing": 6,
+                },
+                "neris": {
+                    "L31.dispatch": "",
+                    "L31.staffing": None,
+                },
+                "neris_uids": {},
+            }
+        }
+        result = _build_neris_patch(diff)
+        actions = result["dispatch"]["properties"]["unit_responses"]
+        assert len(actions) == 1
+        assert actions[0]["action"] == "append"
+        payload = actions[0]["value"]
+        assert payload["staffing"] == 6
+        # Timestamp should be UTC-converted
+        assert payload["dispatch"] == "2026-02-20T10:31:00+00:00"
+
+    def test_response_mode_patch_existing_unit(self):
+        """Response mode change on existing unit produces a patch with string value."""
+        diff = {
+            "units": {
+                "local": {"E31.response_mode": "EMERGENT"},
+                "neris": {"E31.response_mode": "NON_EMERGENT"},
+                "neris_uids": {"E31": 101},
+            }
+        }
+        result = _build_neris_patch(diff)
+        actions = result["dispatch"]["properties"]["unit_responses"]
+        assert len(actions) == 1
+        assert actions[0]["properties"]["response_mode"] == {
+            "action": "set",
+            "value": "EMERGENT",
+        }
+
+    def test_mixed_timestamp_and_staffing_patch(self):
+        """A unit with both timestamp and staffing changes patches both correctly."""
+        diff = {
+            "units": {
+                "local": {
+                    "E31.dispatch": "2026-02-20T10:31:00Z",
+                    "E31.staffing": 6,
+                },
+                "neris": {
+                    "E31.dispatch": "2026-02-20T10:30:00Z",
+                    "E31.staffing": 4,
+                },
+                "neris_uids": {"E31": 42},
+            }
+        }
+        result = _build_neris_patch(diff)
+        actions = result["dispatch"]["properties"]["unit_responses"]
+        assert len(actions) == 1
+        props = actions[0]["properties"]
+        # Timestamp should be UTC-converted
+        assert props["dispatch"] == {"action": "set", "value": "2026-02-20T10:31:00+00:00"}
+        # Staffing should be a plain integer
+        assert props["staffing"] == {"action": "set", "value": 6}
 
     def test_empty_diff_returns_empty_patch(self):
         patch = _build_neris_patch({})


### PR DESCRIPTION
## Summary
- **Bug**: `update_neris_incident` silently dropped staffing (personnel count) and response_mode changes — the diff logic only compared 6 timestamp fields per unit, so it reported "no changes" even when personnel had been updated locally
- Refactored unit diff/patch to use a typed field map that handles timestamps, strings, and integers correctly
- Fixed patch builder to not blindly call `to_utc_iso()` on non-timestamp values (staffing int, response_mode string)
- Fixed closure-in-loop lint warning (B023)

## Test plan
- [x] 9 new tests covering staffing and response_mode diff/patch paths
- [x] All 2200 existing tests pass
- [x] Deployed from branch and verified on ops.sjifire.org
- [ ] Manually test: update unit personnel count on an incident, call update NERIS, verify staffing updates on NERIS side