### PR TITLE
Convert logger f-strings to %s style, enable ruff G rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ select = [
     "T20",    # no print statements
     "A",      # don't shadow builtins
     "PERF",   # performance anti-patterns
+    "G",      # flake8-logging-format (no f-strings in logger calls)
 ]
 ignore = [
     "D100",     # Missing docstring in public module

--- a/src/sjifire/aladtec/client.py
+++ b/src/sjifire/aladtec/client.py
@@ -69,7 +69,7 @@ class AladtecClient:
         """Exit context manager - close HTTP client and log request count."""
         if self.client:
             if self._request_count > 0:
-                logger.info(f"Aladtec API calls: {self._request_count}")
+                logger.info("Aladtec API calls: %d", self._request_count)
             self.client.close()
             self.client = None
 
@@ -109,13 +109,13 @@ class AladtecClient:
         Returns:
             True if login successful, False otherwise
         """
-        logger.info(f"Logging in to {self.base_url}")
+        logger.info("Logging in to %s", self.base_url)
 
         # Get the login page first to establish session
         response = self.get(f"{self.base_url}/")
 
         if response.status_code != 200:
-            logger.error(f"Failed to load login page: {response.status_code}")
+            logger.error("Failed to load login page: %s", response.status_code)
             return False
 
         form_data = {

--- a/src/sjifire/aladtec/member_scraper.py
+++ b/src/sjifire/aladtec/member_scraper.py
@@ -82,7 +82,7 @@ class AladtecMemberScraper(AladtecClient):
         if not self.client:
             raise RuntimeError("Scraper must be used as context manager")
 
-        logger.info(f"Fetching member CSV export (layout={layout})")
+        logger.info("Fetching member CSV export (layout=%s)", layout)
 
         member_list_url = f"{self.base_url}/index.php"
 
@@ -96,10 +96,10 @@ class AladtecMemberScraper(AladtecClient):
 
         response = self.get(member_list_url, params=layout_params)
         if response.status_code != 200:
-            logger.error(f"Failed to load member list: {response.status_code}")
+            logger.error("Failed to load member list: %s", response.status_code)
             return []
 
-        logger.debug(f"Loaded member list page with layout {layout}")
+        logger.debug("Loaded member list page with layout %s", layout)
 
         # Now request the CSV export
         export_params = {
@@ -110,7 +110,7 @@ class AladtecMemberScraper(AladtecClient):
         response = self.get(member_list_url, params=export_params)
 
         if response.status_code != 200:
-            logger.error(f"Failed to get CSV export: {response.status_code}")
+            logger.error("Failed to get CSV export: %s", response.status_code)
             return self._scrape_members_html()
 
         # Check if we got CSV content (should have commas and likely "Name" header)
@@ -119,7 +119,7 @@ class AladtecMemberScraper(AladtecClient):
             logger.warning("Export response doesn't look like CSV, trying HTML scrape")
             return self._scrape_members_html()
 
-        logger.debug(f"Got CSV export ({len(content)} bytes)")
+        logger.debug("Got CSV export (%d bytes)", len(content))
         members = self._parse_csv(content)
 
         # Optionally enrich with full position and schedule lists
@@ -130,7 +130,7 @@ class AladtecMemberScraper(AladtecClient):
         if include_inactive:
             inactive_members = self._get_inactive_members()
             members.extend(inactive_members)
-            logger.info(f"Total members (active + inactive): {len(members)}")
+            logger.info("Total members (active + inactive): %d", len(members))
 
         return members
 
@@ -160,7 +160,7 @@ class AladtecMemberScraper(AladtecClient):
 
         response = self._get_with_retry(member_list_url, params=layout_params)
         if response.status_code != 200:
-            logger.error(f"Failed to load inactive member list: {response.status_code}")
+            logger.error("Failed to load inactive member list: %s", response.status_code)
             return []
 
         # Export CSV
@@ -171,7 +171,7 @@ class AladtecMemberScraper(AladtecClient):
 
         response = self._get_with_retry(member_list_url, params=export_params)
         if response.status_code != 200:
-            logger.error(f"Failed to export inactive members: {response.status_code}")
+            logger.error("Failed to export inactive members: %s", response.status_code)
             return []
 
         content = response.text
@@ -265,7 +265,7 @@ class AladtecMemberScraper(AladtecClient):
             )
             members.append(member)
 
-        logger.info(f"Parsed {len(members)} inactive members")
+        logger.info("Parsed %d inactive members", len(members))
         return members
 
     def _parse_csv(self, csv_content: str) -> list[Member]:
@@ -300,14 +300,14 @@ class AladtecMemberScraper(AladtecClient):
 
         # Log available columns for debugging
         if reader.fieldnames:
-            logger.debug(f"CSV columns: {list(reader.fieldnames)}")
+            logger.debug("CSV columns: %s", list(reader.fieldnames))
 
         for row in reader:
             member = self._parse_csv_row(row)
             if member:
                 members.append(member)
 
-        logger.info(f"Parsed {len(members)} members from CSV")
+        logger.info("Parsed %d members from CSV", len(members))
         return members
 
     def _parse_csv_row(self, row: dict) -> Member | None:
@@ -485,7 +485,7 @@ class AladtecMemberScraper(AladtecClient):
                     name = name_match.group(1)
                     user_map[name] = user_id
 
-        logger.info(f"Got {len(user_map)} user IDs from roster")
+        logger.info("Got %d user IDs from roster", len(user_map))
         return user_map
 
     @retry(
@@ -502,7 +502,7 @@ class AladtecMemberScraper(AladtecClient):
         """
         response = self.get(url, **kwargs)
         if response.status_code == 429:
-            logger.warning(f"Rate limited on {url}, retrying...")
+            logger.warning("Rate limited on %s, retrying...", url)
         return response
 
     def _get_member_detail_page(self, user_id: str) -> BeautifulSoup | None:
@@ -529,7 +529,7 @@ class AladtecMemberScraper(AladtecClient):
 
         if response.status_code != 200:
             logger.warning(
-                f"Failed to fetch detail page for user {user_id}: HTTP {response.status_code}"
+                "Failed to fetch detail page for user %s: HTTP %s", user_id, response.status_code
             )
             return None
 
@@ -625,7 +625,7 @@ class AladtecMemberScraper(AladtecClient):
         if not self.client:
             return members
 
-        logger.info(f"Enriching {len(members)} members with position and schedule data")
+        logger.info("Enriching %d members with position and schedule data", len(members))
 
         # Get user ID mapping
         user_map = self.get_user_id_map()
@@ -662,7 +662,10 @@ class AladtecMemberScraper(AladtecClient):
 
             if positions or schedules:
                 logger.debug(
-                    f"{member.display_name}: {len(positions)} positions, {len(schedules)} schedules"
+                    "%s: %d positions, %d schedules",
+                    member.display_name,
+                    len(positions),
+                    len(schedules),
                 )
 
         if failed_members:
@@ -713,7 +716,7 @@ class AladtecMemberScraper(AladtecClient):
                     if member:
                         members.append(member)
 
-        logger.info(f"Scraped {len(members)} members from HTML")
+        logger.info("Scraped %d members from HTML", len(members))
         return members
 
     def _parse_html_row(self, cells) -> Member | None:

--- a/src/sjifire/aladtec/schedule_scraper.py
+++ b/src/sjifire/aladtec/schedule_scraper.py
@@ -154,13 +154,13 @@ class AladtecScheduleScraper(AladtecClient):
         )
 
         if response.status_code != 200:
-            logger.error(f"Failed to fetch schedule: {response.status_code}")
+            logger.error("Failed to fetch schedule: %s", response.status_code)
             return {}
 
         try:
             data = json.loads(response.text)
         except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON response: {e}")
+            logger.error("Invalid JSON response: %s", e)
             return {}
 
         return_data = data.get("return_data", "")
@@ -208,7 +208,7 @@ class AladtecScheduleScraper(AladtecClient):
 
             if not data:
                 # No data returned, advance by 5 days and retry
-                logger.debug(f"No data from {current_start}, advancing by 5 days")
+                logger.debug("No data from %s, advancing by 5 days", current_start)
                 current_start += timedelta(days=5)
                 continue
 
@@ -228,12 +228,12 @@ class AladtecScheduleScraper(AladtecClient):
 
             if next_start <= current_start:
                 # No progress made, force advance to avoid infinite loop
-                logger.debug(f"No progress from {current_start}, forcing advance")
+                logger.debug("No progress from %s, forcing advance", current_start)
                 current_start += timedelta(days=5)
             else:
                 current_start = next_start
 
-        logger.debug(f"Fetched {len(all_data)} days for {month_str} in {fetch_count} requests")
+        logger.debug("Fetched %d days for %s in %d requests", len(all_data), month_str, fetch_count)
         return all_data
 
     def parse_day_html(self, date_str: str, html: str) -> DaySchedule:
@@ -335,7 +335,7 @@ class AladtecScheduleScraper(AladtecClient):
         end_month = end_date.replace(day=1)
 
         while current <= end_month:
-            logger.info(f"Fetching {current.strftime('%B %Y')}...")
+            logger.info("Fetching %s...", current.strftime("%B %Y"))
             month_data = self.fetch_month_schedule(current)
 
             if month_data:
@@ -359,7 +359,7 @@ class AladtecScheduleScraper(AladtecClient):
                 if day_schedule.entries:
                     schedules.append(day_schedule)
 
-        logger.info(f"Fetched {len(schedules)} days with schedule data")
+        logger.info("Fetched %d days with schedule data", len(schedules))
         return schedules
 
     def get_schedule_months_ahead(self, months: int = 6) -> list[DaySchedule]:
@@ -416,7 +416,7 @@ def save_schedules(schedules: list[DaySchedule], path: str | Path) -> None:
         data.append(day_dict)
 
     Path(path).write_text(json.dumps(data, indent=2))
-    logger.info(f"Saved {len(schedules)} days of schedule data to {path}")
+    logger.info("Saved %d days of schedule data to %s", len(schedules), path)
 
 
 def load_schedules(path: str | Path) -> list[DaySchedule]:
@@ -456,5 +456,5 @@ def load_schedules(path: str | Path) -> list[DaySchedule]:
         )
         schedules.append(day)
 
-    logger.info(f"Loaded {len(schedules)} days of schedule data from {path}")
+    logger.info("Loaded %d days of schedule data from %s", len(schedules), path)
     return schedules

--- a/src/sjifire/calendar/duty_sync.py
+++ b/src/sjifire/calendar/duty_sync.py
@@ -219,12 +219,12 @@ class DutyCalendarSync:
                     if group.group_types and "Unified" in group.group_types:
                         self._group_id = group.id
                         self._is_group = True
-                        logger.info(f"Detected M365 group: {group.display_name} ({group.id})")
+                        logger.info("Detected M365 group: %s (%s)", group.display_name, group.id)
                         logger.info("Switching to delegated auth for group calendar access")
                         self._setup_delegated_client()
                         return True
         except Exception as e:
-            logger.debug(f"Error checking for group: {e}")
+            logger.debug("Error checking for group: %s", e)
 
         self._is_group = False
         return False
@@ -251,7 +251,7 @@ class DutyCalendarSync:
             self._delegated_client = GraphServiceClient(credentials=delegated_credential)
             logger.debug("Delegated auth client initialized with ROPC")
         except Exception as e:
-            logger.error(f"Failed to set up delegated auth: {e}")
+            logger.error("Failed to set up delegated auth: %s", e)
             raise RuntimeError(
                 "Delegated auth required for M365 group calendars. "
                 "Ensure service account credentials are set in environment "
@@ -310,9 +310,9 @@ class DutyCalendarSync:
                                     "phone": user.mobile_phone,
                                 }
 
-            logger.info(f"Loaded {len(self._user_cache)} user contacts")
+            logger.info("Loaded %d user contacts", len(self._user_cache))
         except Exception as e:
-            logger.error(f"Failed to load user contacts: {e}")
+            logger.error("Failed to load user contacts: %s", e)
             self._user_cache = {}
 
         return self._user_cache
@@ -429,7 +429,7 @@ class DutyCalendarSync:
         # Sort by date
         events.sort(key=lambda e: e.event_date)
 
-        logger.info(f"Converted {len(schedules)} days to {len(events)} all-day events")
+        logger.info("Converted %d days to %d all-day events", len(schedules), len(events))
         return events
 
     def _get_filled_entries(self, day_schedule: DaySchedule) -> list[ScheduleEntry]:
@@ -542,7 +542,7 @@ class DutyCalendarSync:
                     request_configuration=config
                 )
         except Exception as e:
-            logger.error(f"Failed to fetch existing events: {e}")
+            logger.error("Failed to fetch existing events: %s", e)
             return {}
 
         events_by_date: dict[date, tuple[str, str]] = {}
@@ -558,7 +558,7 @@ class DutyCalendarSync:
                         body_content = item.body.content
                     events_by_date[event_date] = (item.id, body_content)
 
-        logger.debug(f"Found {len(events_by_date)} existing On Duty events")
+        logger.debug("Found %d existing On Duty events", len(events_by_date))
         return events_by_date
 
     def _parse_graph_date(self, dt: DateTimeTimeZone | None) -> date | None:
@@ -609,7 +609,7 @@ class DutyCalendarSync:
                 result = await client.users.by_user_id(self.mailbox).events.post(graph_event)
             return result.id if result else None
         except Exception as e:
-            logger.error(f"Failed to create event: {e}")
+            logger.error("Failed to create event: %s", e)
             return None
 
     async def update_event(self, event: AllDayDutyEvent) -> bool:
@@ -657,7 +657,7 @@ class DutyCalendarSync:
                 )
             return True
         except Exception as e:
-            logger.error(f"Failed to update event {event.event_id}: {e}")
+            logger.error("Failed to update event %s: %s", event.event_id, e)
             return False
 
     async def delete_event(self, event_id: str) -> bool:
@@ -675,7 +675,7 @@ class DutyCalendarSync:
                 await client.users.by_user_id(self.mailbox).events.by_event_id(event_id).delete()
             return True
         except Exception as e:
-            logger.error(f"Failed to delete event {event_id}: {e}")
+            logger.error("Failed to delete event %s: %s", event_id, e)
             return False
 
     async def _create_event_with_semaphore(
@@ -844,11 +844,11 @@ class DutyCalendarSync:
 
         # Log what we're doing
         if events_to_create:
-            logger.info(f"Creating {len(events_to_create)} events...")
+            logger.info("Creating %d events...", len(events_to_create))
         if events_to_update:
-            logger.info(f"Updating {len(events_to_update)} events...")
+            logger.info("Updating %d events...", len(events_to_update))
         if unchanged_count:
-            logger.info(f"Skipping {unchanged_count} unchanged events")
+            logger.info("Skipping %d unchanged events", unchanged_count)
 
         if dry_run:
             result.events_created = len(events_to_create)
@@ -931,7 +931,7 @@ class DutyCalendarSync:
                 logger.info("No On Duty events found in date range")
                 return result
 
-            logger.info(f"Found {len(existing_by_date)} On Duty events to delete")
+            logger.info("Found %d On Duty events to delete", len(existing_by_date))
 
             # Extract just the event IDs from tuples (id, body)
             events_to_delete = {
@@ -940,10 +940,10 @@ class DutyCalendarSync:
 
             if dry_run:
                 for event_date in sorted(events_to_delete.keys()):
-                    logger.info(f"Would delete event for {event_date}")
+                    logger.info("Would delete event for %s", event_date)
                 result.events_deleted = len(events_to_delete)
             else:
-                logger.info(f"Deleting {len(events_to_delete)} events...")
+                logger.info("Deleting %d events...", len(events_to_delete))
                 deleted, errors = await self.delete_events_batch(events_to_delete)
                 result.events_deleted = deleted
                 result.errors.extend(errors)

--- a/src/sjifire/calendar/personal_sync.py
+++ b/src/sjifire/calendar/personal_sync.py
@@ -136,10 +136,10 @@ class PersonalCalendarSync:
                 color="preset6",  # Orange
             )
             await self.client.users.by_user_id(user_email).outlook.master_categories.post(new_cat)
-            logger.info(f"Created Aladtec category for {user_email}")
+            logger.info("Created Aladtec category for %s", user_email)
             return True
         except Exception as e:
-            logger.warning(f"Could not create Aladtec category for {user_email}: {e}")
+            logger.warning("Could not create Aladtec category for %s: %s", user_email, e)
             return False
 
     async def _get_primary_calendar_id(self, user_email: str) -> str | None:
@@ -150,7 +150,7 @@ class PersonalCalendarSync:
             if calendar and calendar.id:
                 return calendar.id
         except Exception as e:
-            logger.error(f"Failed to get primary calendar for {user_email}: {e}")
+            logger.error("Failed to get primary calendar for %s: %s", user_email, e)
         return None
 
     async def get_or_create_calendar(self, user_email: str) -> str | None:
@@ -298,7 +298,7 @@ class PersonalCalendarSync:
             return events_by_key
 
         except Exception as e:
-            logger.error(f"Failed to get existing events for {user_email}: {e}")
+            logger.error("Failed to get existing events for %s: %s", user_email, e)
             return {}
 
     async def create_event(
@@ -342,7 +342,7 @@ class PersonalCalendarSync:
             )
             return True
         except Exception as e:
-            logger.error(f"Failed to create event for {user_email}: {e}")
+            logger.error("Failed to create event for %s: %s", user_email, e)
             return False
 
     async def update_event(
@@ -388,7 +388,7 @@ class PersonalCalendarSync:
             )
             return True
         except Exception as e:
-            logger.error(f"Failed to update event {event_id}: {e}")
+            logger.error("Failed to update event %s: %s", event_id, e)
             return False
 
     async def delete_event(
@@ -407,7 +407,7 @@ class PersonalCalendarSync:
             )
             return True
         except Exception as e:
-            logger.error(f"Failed to delete event {event_id}: {e}")
+            logger.error("Failed to delete event %s: %s", event_id, e)
             return False
 
     async def get_aladtec_category_events(
@@ -448,7 +448,7 @@ class PersonalCalendarSync:
             return events
 
         except Exception as e:
-            logger.error(f"Failed to get Aladtec events for {user_email}: {e}")
+            logger.error("Failed to get Aladtec events for %s: %s", user_email, e)
             return []
 
     async def purge_aladtec_events(
@@ -468,7 +468,7 @@ class PersonalCalendarSync:
         # Get primary calendar
         calendar_id = await self._get_primary_calendar_id(user_email)
         if not calendar_id:
-            logger.error(f"Could not get primary calendar for {user_email}")
+            logger.error("Could not get primary calendar for %s", user_email)
             return 0, 1
 
         # Mark as using primary calendar for category filtering
@@ -478,14 +478,14 @@ class PersonalCalendarSync:
         events = await self.get_aladtec_category_events(user_email, calendar_id)
 
         if not events:
-            logger.info(f"No Aladtec events found for {user_email}")
+            logger.info("No Aladtec events found for %s", user_email)
             return 0, 0
 
-        logger.info(f"Found {len(events)} Aladtec events for {user_email}")
+        logger.info("Found %d Aladtec events for %s", len(events), user_email)
 
         if dry_run:
             for _event_id, subject, start_date in events:
-                logger.info(f"  Would delete: {start_date} - {subject}")
+                logger.info("  Would delete: %s - %s", start_date, subject)
             return len(events), 0
 
         # Delete events
@@ -503,7 +503,7 @@ class PersonalCalendarSync:
         for (_event_id, subject, start_date), success in zip(events, results, strict=True):
             if success:
                 deleted += 1
-                logger.debug(f"  Deleted: {start_date} - {subject}")
+                logger.debug("  Deleted: %s - %s", start_date, subject)
             else:
                 errors += 1
 
@@ -578,7 +578,7 @@ class PersonalCalendarSync:
                 if normalize_body_for_comparison(new_body) != normalize_body_for_comparison(
                     existing_body
                 ):
-                    logger.debug(f"Body mismatch for {key}")
+                    logger.debug("Body mismatch for %s", key)
                     to_update.append((key, existing[key].event_id))
 
         if dry_run:
@@ -587,12 +587,12 @@ class PersonalCalendarSync:
             result.events_deleted = len(to_delete)
             for key in to_create:
                 entry = entries_by_key[key]
-                logger.info(f"Would create: {entry.date} - {entry.position}")
+                logger.info("Would create: %s - %s", entry.date, entry.position)
             for key, _ in to_update:
                 entry = entries_by_key[key]
-                logger.info(f"Would update: {entry.date} - {entry.position}")
+                logger.info("Would update: %s - %s", entry.date, entry.position)
             for key in to_delete:
-                logger.info(f"Would delete: {key}")
+                logger.info("Would delete: %s", key)
         else:
             # Create new events
             semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)

--- a/src/sjifire/core/backup.py
+++ b/src/sjifire/core/backup.py
@@ -66,7 +66,7 @@ def backup_aladtec_members(
     with filepath.open("w") as f:
         json.dump(data, f, indent=2, default=str)
 
-    logger.info(f"Backed up {len(members)} Aladtec members to {filepath}")
+    logger.info("Backed up %d Aladtec members to %s", len(members), filepath)
     return filepath
 
 
@@ -101,7 +101,7 @@ def backup_entra_users(
     with filepath.open("w") as f:
         json.dump(data, f, indent=2, default=str)
 
-    logger.info(f"Backed up {len(users)} Entra users to {filepath}")
+    logger.info("Backed up %d Entra users to %s", len(users), filepath)
     return filepath
 
 
@@ -185,7 +185,7 @@ def backup_entra_groups(
     with filepath.open("w") as f:
         json.dump(data, f, indent=2, default=str)
 
-    logger.info(f"Backed up {len(groups)} Entra groups to {filepath}")
+    logger.info("Backed up %d Entra groups to %s", len(groups), filepath)
     return filepath
 
 
@@ -219,7 +219,7 @@ def backup_mail_groups(
     with filepath.open("w") as f:
         json.dump(data, f, indent=2, default=str)
 
-    logger.info(f"Backed up {len(groups)} mail groups to {filepath}")
+    logger.info("Backed up %d mail groups to %s", len(groups), filepath)
     return filepath
 
 

--- a/src/sjifire/core/normalize.py
+++ b/src/sjifire/core/normalize.py
@@ -91,7 +91,7 @@ def validate_email(email: str | None, context: str = "") -> str | None:
         result = ev(email, check_deliverability=False)
         return result.normalized
     except EmailNotValidError as e:
-        logger.warning(f"Invalid email '{email}'{f' for {context}' if context else ''}: {e}")
+        logger.warning("Invalid email '%s'%s: %s", email, f" for {context}" if context else "", e)
         return None
 
 

--- a/src/sjifire/entra/aladtec_import.py
+++ b/src/sjifire/entra/aladtec_import.py
@@ -79,8 +79,10 @@ class AladtecImporter:
             ImportResult with details of the operation
         """
         logger.info(
-            f"Importing {len(members)} members (dry_run={dry_run}, "
-            f"disable_inactive={disable_inactive})"
+            "Importing %d members (dry_run=%s, disable_inactive=%s)",
+            len(members),
+            dry_run,
+            disable_inactive,
         )
 
         # Build lookup of existing Entra users
@@ -107,7 +109,7 @@ class AladtecImporter:
                     disable_inactive=disable_inactive,
                 )
             except Exception as e:
-                logger.error(f"Error processing {member.display_name}: {e}")
+                logger.error("Error processing %s: %s", member.display_name, e)
                 result.errors.append(
                     {
                         "member": member.display_name,
@@ -115,7 +117,7 @@ class AladtecImporter:
                     }
                 )
 
-        logger.info(f"Import complete: {result.summary()}")
+        logger.info("Import complete: %s", result.summary())
         return result
 
     async def _process_member(
@@ -215,7 +217,7 @@ class AladtecImporter:
                             "action": "would disable and remove licenses",
                         }
                     )
-                    logger.info(f"Would disable and remove licenses: {member.display_name}")
+                    logger.info("Would disable and remove licenses: %s", member.display_name)
                 else:
                     disable_ok, license_ok = await self.user_manager.disable_and_remove_licenses(
                         existing.id
@@ -230,10 +232,10 @@ class AladtecImporter:
                             }
                         )
                         if license_ok:
-                            logger.info(f"Disabled and removed licenses: {member.display_name}")
+                            logger.info("Disabled and removed licenses: %s", member.display_name)
                         else:
                             logger.warning(
-                                f"Disabled {member.display_name} but failed to remove licenses"
+                                "Disabled %s but failed to remove licenses", member.display_name
                             )
                     else:
                         result.errors.append(
@@ -260,7 +262,7 @@ class AladtecImporter:
                         "email": member.email,
                     }
                 )
-                logger.info(f"Would update: {member.display_name}")
+                logger.info("Would update: %s", member.display_name)
             else:
                 # Build business phones list from home_phone if available
                 business_phones = [member.home_phone] if member.home_phone else None
@@ -300,7 +302,7 @@ class AladtecImporter:
                             "email": member.email,
                         }
                     )
-                    logger.info(f"Updated: {member.display_name}")
+                    logger.info("Updated: %s", member.display_name)
                 else:
                     result.errors.append(
                         {
@@ -351,7 +353,7 @@ class AladtecImporter:
                     "upn": upn,
                 }
             )
-            logger.info(f"Would create: {member.display_name} ({upn})")
+            logger.info("Would create: %s (%s)", member.display_name, upn)
         else:
             # Build business phones list from home_phone if available
             business_phones = [member.home_phone] if member.home_phone else None
@@ -391,7 +393,7 @@ class AladtecImporter:
                         "upn": upn,
                     }
                 )
-                logger.info(f"Created: {member.display_name} ({upn})")
+                logger.info("Created: %s (%s)", member.display_name, upn)
             else:
                 result.errors.append(
                     {
@@ -461,8 +463,10 @@ class AladtecImporter:
                         # Aladtec date is newer - flag but don't update
                         entra_date = existing.employee_hire_date[:10]
                         logger.warning(
-                            f"Hire date conflict for {member.display_name}: "
-                            f"Aladtec={member_date} is newer than Entra={entra_date}"
+                            "Hire date conflict for %s: Aladtec=%s is newer than Entra=%s",
+                            member.display_name,
+                            member_date,
+                            entra_date,
                         )
             else:
                 # Entra has no hire date, safe to set

--- a/src/sjifire/entra/groups.py
+++ b/src/sjifire/entra/groups.py
@@ -115,7 +115,7 @@ class EntraGroupManager:
                     if include_types is None or entra_group.group_type in include_types:
                         groups.append(entra_group)
 
-        logger.info(f"Found {len(groups)} groups")
+        logger.info("Found %d groups", len(groups))
         return groups
 
     def _to_entra_group(self, group: Group) -> EntraGroup:
@@ -169,10 +169,10 @@ class EntraGroupManager:
 
         try:
             await self.client.groups.by_group_id(group_id).members.ref.post(request_body)
-            logger.info(f"Added user {user_id} to group {group_id}")
+            logger.info("Added user %s to group %s", user_id, group_id)
             return True
         except Exception as e:
-            logger.error(f"Failed to add user {user_id} to group {group_id}: {e}")
+            logger.error("Failed to add user %s to group %s: %s", user_id, group_id, e)
             return False
 
     async def remove_user_from_group(self, group_id: str, user_id: str) -> bool:
@@ -191,10 +191,10 @@ class EntraGroupManager:
                 .members.by_directory_object_id(user_id)
                 .ref.delete()
             )
-            logger.info(f"Removed user {user_id} from group {group_id}")
+            logger.info("Removed user %s from group %s", user_id, group_id)
             return True
         except Exception as e:
-            logger.error(f"Failed to remove user {user_id} from group {group_id}: {e}")
+            logger.error("Failed to remove user %s from group %s: %s", user_id, group_id, e)
             return False
 
     async def delete_group(self, group_id: str) -> bool:
@@ -208,10 +208,10 @@ class EntraGroupManager:
         """
         try:
             await self.client.groups.by_group_id(group_id).delete()
-            logger.info(f"Deleted group: {group_id}")
+            logger.info("Deleted group: %s", group_id)
             return True
         except Exception as e:
-            logger.error(f"Failed to delete group {group_id}: {e}")
+            logger.error("Failed to delete group %s: %s", group_id, e)
             return False
 
     async def create_security_group(
@@ -246,10 +246,10 @@ class EntraGroupManager:
         try:
             created = await self.client.groups.post(group)
             if created:
-                logger.info(f"Created security group: {display_name} (ID: {created.id})")
+                logger.info("Created security group: %s (ID: %s)", display_name, created.id)
                 return self._to_entra_group(created)
         except Exception as e:
-            logger.error(f"Failed to create security group {display_name}: {e}")
+            logger.error("Failed to create security group %s: %s", display_name, e)
 
         return None
 
@@ -294,11 +294,14 @@ class EntraGroupManager:
             created = await self.client.groups.post(group)
             if created:
                 logger.info(
-                    f"Created M365 group: {display_name} ({mail_nickname}@...) (ID: {created.id})"
+                    "Created M365 group: %s (%s@...) (ID: %s)",
+                    display_name,
+                    mail_nickname,
+                    created.id,
                 )
                 return self._to_entra_group(created)
         except Exception as e:
-            logger.error(f"Failed to create M365 group {display_name}: {e}")
+            logger.error("Failed to create M365 group %s: %s", display_name, e)
 
         return None
 
@@ -320,10 +323,10 @@ class EntraGroupManager:
 
         try:
             await self.client.groups.by_group_id(group_id).patch(group)
-            logger.info(f"Updated description for group {group_id}")
+            logger.info("Updated description for group %s", group_id)
             return True
         except Exception as e:
-            logger.error(f"Failed to update group {group_id} description: {e}")
+            logger.error("Failed to update group %s description: %s", group_id, e)
             return False
 
     async def update_group_visibility(
@@ -349,10 +352,10 @@ class EntraGroupManager:
 
         try:
             await self.client.groups.by_group_id(group_id).patch(group)
-            logger.info(f"Updated visibility for group {group_id} to {visibility}")
+            logger.info("Updated visibility for group %s to %s", group_id, visibility)
             return True
         except Exception as e:
-            logger.warning(f"Failed to update group {group_id} visibility: {e}")
+            logger.warning("Failed to update group %s visibility: %s", group_id, e)
             return False
 
     async def get_group_by_mail_nickname(self, mail_nickname: str) -> EntraGroup | None:
@@ -383,7 +386,7 @@ class EntraGroupManager:
             if result and result.value and len(result.value) > 0:
                 return self._to_entra_group(result.value[0])
         except Exception as e:
-            logger.error(f"Failed to find group by mail nickname {mail_nickname}: {e}")
+            logger.error("Failed to find group by mail nickname %s: %s", mail_nickname, e)
 
         return None
 
@@ -415,6 +418,6 @@ class EntraGroupManager:
             if result and result.value and len(result.value) > 0:
                 return self._to_entra_group(result.value[0])
         except Exception as e:
-            logger.error(f"Failed to find group {display_name}: {e}")
+            logger.error("Failed to find group %s: %s", display_name, e)
 
         return None

--- a/src/sjifire/entra/users.py
+++ b/src/sjifire/entra/users.py
@@ -223,7 +223,7 @@ class EntraUserManager:
                         continue
                     users.append(self._to_entra_user(user))
 
-        logger.info(f"Found {len(users)} users")
+        logger.info("Found %d users", len(users))
         return users
 
     async def get_employees(self, include_disabled: bool = False) -> list[EntraUser]:
@@ -304,7 +304,7 @@ class EntraUserManager:
             if user:
                 return self._to_entra_user(user)
         except Exception as e:
-            logger.debug(f"User not found: {upn} - {e}")
+            logger.debug("User not found: %s - %s", upn, e)
         return None
 
     async def create_user(
@@ -373,7 +373,7 @@ class EntraUserManager:
             try:
                 hire_date = datetime.fromisoformat(employee_hire_date.replace("/", "-"))
             except ValueError:
-                logger.warning(f"Invalid hire date format: {employee_hire_date}")
+                logger.warning("Invalid hire date format: %s", employee_hire_date)
 
         # Build extension attributes if any are provided
         ext_attrs = None
@@ -416,10 +416,10 @@ class EntraUserManager:
         try:
             created = await self.client.users.post(user)
             if created:
-                logger.info(f"Created user: {display_name} ({upn})")
+                logger.info("Created user: %s (%s)", display_name, upn)
                 return self._to_entra_user(created)
         except Exception as e:
-            logger.error(f"Failed to create user {upn}: {e}")
+            logger.error("Failed to create user %s: %s", upn, e)
 
         return None
 
@@ -477,7 +477,7 @@ class EntraUserManager:
             try:
                 hire_date = datetime.fromisoformat(employee_hire_date.replace("/", "-"))
             except ValueError:
-                logger.warning(f"Invalid hire date format: {employee_hire_date}")
+                logger.warning("Invalid hire date format: %s", employee_hire_date)
 
         # Build user with non-None values, use additional_data for fields to clear
         user = User(
@@ -561,7 +561,7 @@ class EntraUserManager:
 
         try:
             await self.client.users.by_user_id(user_id).patch(user)
-            logger.info(f"Updated user: {user_id}")
+            logger.info("Updated user: %s", user_id)
             return True
         except Exception as e:
             error_str = str(e)
@@ -577,7 +577,7 @@ class EntraUserManager:
                 if personal_email:
                     skipped.append("otherMails")
                 logger.warning(
-                    f"Permission denied for {user_id}, retrying without: {', '.join(skipped)}"
+                    "Permission denied for %s, retrying without: %s", user_id, ", ".join(skipped)
                 )
                 # Retry without sensitive fields (mobilePhone, businessPhones, otherMails)
                 # Remove those from fields_to_clear too
@@ -629,17 +629,19 @@ class EntraUserManager:
                 try:
                     await self.client.users.by_user_id(user_id).patch(user_retry)
                     logger.info(
-                        f"Updated user (partial): {user_id} (skipped: {', '.join(skipped)})"
+                        "Updated user (partial): %s (skipped: %s)", user_id, ", ".join(skipped)
                     )
                     return True
                 except Exception as retry_error:
                     logger.error(
-                        f"Failed to update user {user_id} even without "
-                        f"{', '.join(skipped)}: {retry_error}"
+                        "Failed to update user %s even without %s: %s",
+                        user_id,
+                        ", ".join(skipped),
+                        retry_error,
                     )
                     return False
 
-            logger.error(f"Failed to update user {user_id}: {e}")
+            logger.error("Failed to update user %s: %s", user_id, e)
             return False
 
     async def disable_user(self, user_id: str) -> bool:
@@ -674,10 +676,10 @@ class EntraUserManager:
 
         try:
             await self.client.users.by_user_id(user_id).patch(user)
-            logger.info(f"Disabled user: {user_id}")
+            logger.info("Disabled user: %s", user_id)
             return True
         except Exception as e:
-            logger.error(f"Failed to disable user {user_id}: {e}")
+            logger.error("Failed to disable user %s: %s", user_id, e)
             return False
 
     async def enable_user(self, user_id: str) -> bool:
@@ -693,10 +695,10 @@ class EntraUserManager:
 
         try:
             await self.client.users.by_user_id(user_id).patch(user)
-            logger.info(f"Enabled user: {user_id}")
+            logger.info("Enabled user: %s", user_id)
             return True
         except Exception as e:
-            logger.error(f"Failed to enable user {user_id}: {e}")
+            logger.error("Failed to enable user %s: %s", user_id, e)
             return False
 
     async def get_user_licenses(self, user_id: str) -> list[str]:
@@ -714,7 +716,7 @@ class EntraUserManager:
                 return [str(lic.sku_id) for lic in result.value if lic.sku_id]
             return []
         except Exception as e:
-            logger.error(f"Failed to get licenses for {user_id}: {e}")
+            logger.error("Failed to get licenses for %s: %s", user_id, e)
             return []
 
     async def remove_all_licenses(self, user_id: str) -> bool:
@@ -730,7 +732,7 @@ class EntraUserManager:
         license_ids = await self.get_user_licenses(user_id)
 
         if not license_ids:
-            logger.info(f"User {user_id} has no licenses to remove")
+            logger.info("User %s has no licenses to remove", user_id)
             return True
 
         try:
@@ -739,10 +741,10 @@ class EntraUserManager:
                 remove_licenses=[UUID(lic_id) for lic_id in license_ids],
             )
             await self.client.users.by_user_id(user_id).assign_license.post(request_body)
-            logger.info(f"Removed {len(license_ids)} license(s) from user: {user_id}")
+            logger.info("Removed %d license(s) from user: %s", len(license_ids), user_id)
             return True
         except Exception as e:
-            logger.error(f"Failed to remove licenses from {user_id}: {e}")
+            logger.error("Failed to remove licenses from %s: %s", user_id, e)
             return False
 
     async def disable_and_remove_licenses(self, user_id: str) -> tuple[bool, bool]:

--- a/src/sjifire/exchange/client.py
+++ b/src/sjifire/exchange/client.py
@@ -174,7 +174,7 @@ class ExchangeOnlineClient:
             )
 
             if result.returncode != 0:
-                logger.error(f"PowerShell error: {result.stderr}")
+                logger.error("PowerShell error: %s", result.stderr)
                 return None
 
             output = result.stdout.strip()
@@ -197,7 +197,7 @@ class ExchangeOnlineClient:
                     # Only warn if output looks like it might contain JSON data
                     # (not just banner text or empty results)
                     if "{" in output or "[" in output:
-                        logger.warning(f"Failed to parse JSON output: {output[:200]}")
+                        logger.warning("Failed to parse JSON output: %s", output[:200])
                     return {"raw": output}
 
             return output
@@ -209,7 +209,7 @@ class ExchangeOnlineClient:
             logger.error("PowerShell (pwsh) not found. Install PowerShell 7+.")
             return None
         except Exception as e:
-            logger.error(f"Failed to run PowerShell: {e}")
+            logger.error("Failed to run PowerShell: %s", e)
             return None
 
     async def get_distribution_group(self, identity: str) -> ExchangeGroup | None:
@@ -352,7 +352,7 @@ class ExchangeOnlineClient:
 
         result = self._run_powershell(commands)
         if result and isinstance(result, dict) and "Identity" in result:
-            logger.info(f"Created mail-enabled security group: {display_name}")
+            logger.info("Created mail-enabled security group: %s", display_name)
             return ExchangeGroup(
                 identity=result.get("Identity", name),
                 display_name=result.get("DisplayName", display_name),
@@ -360,7 +360,7 @@ class ExchangeOnlineClient:
                 group_type="MailEnabledSecurity",
             )
 
-        logger.error(f"Failed to create mail-enabled security group: {name}")
+        logger.error("Failed to create mail-enabled security group: %s", name)
         return None
 
     async def update_distribution_group_description(
@@ -386,10 +386,10 @@ class ExchangeOnlineClient:
 
         result = self._run_powershell(commands, parse_json=False)
         if result and "SUCCESS" in str(result):
-            logger.info(f"Updated description for {identity}")
+            logger.info("Updated description for %s", identity)
             return True
 
-        logger.error(f"Failed to update description for {identity}")
+        logger.error("Failed to update description for %s", identity)
         return False
 
     async def update_distribution_group_managed_by(
@@ -417,10 +417,10 @@ class ExchangeOnlineClient:
 
         result = self._run_powershell(commands, parse_json=False)
         if result and "SUCCESS" in str(result):
-            logger.info(f"Updated ManagedBy for {identity} to {managed_by}")
+            logger.info("Updated ManagedBy for %s to %s", identity, managed_by)
             return True
 
-        logger.error(f"Failed to update ManagedBy for {identity}")
+        logger.error("Failed to update ManagedBy for %s", identity)
         return False
 
     async def set_distribution_group_aliases(
@@ -461,10 +461,10 @@ class ExchangeOnlineClient:
 
         result = self._run_powershell(commands, parse_json=False)
         if result and "SUCCESS" in str(result):
-            logger.info(f"Added aliases to {identity}: {', '.join(aliases)}")
+            logger.info("Added aliases to %s: %s", identity, ", ".join(aliases))
             return True
 
-        logger.error(f"Failed to add aliases to {identity}: {result}")
+        logger.error("Failed to add aliases to %s: %s", identity, result)
         return False
 
     async def update_group_settings(
@@ -509,12 +509,12 @@ class ExchangeOnlineClient:
         result = self._run_powershell(commands, parse_json=False)
         if result and "SUCCESS" in str(result):
             if description:
-                logger.info(f"Updated description for {identity}")
+                logger.info("Updated description for %s", identity)
             if managed_by:
-                logger.info(f"Updated ManagedBy for {identity} to {managed_by}")
+                logger.info("Updated ManagedBy for %s to %s", identity, managed_by)
             return True
 
-        logger.error(f"Failed to update settings for {identity}")
+        logger.error("Failed to update settings for %s", identity)
         return False
 
     async def delete_distribution_group(self, identity: str) -> bool:
@@ -534,7 +534,7 @@ class ExchangeOnlineClient:
 
         result = self._run_powershell(commands, parse_json=False)
         if result and "SUCCESS" in str(result):
-            logger.info(f"Deleted distribution group: {identity}")
+            logger.info("Deleted distribution group: %s", identity)
             return True
 
         # Check if group just doesn't exist (not an error)
@@ -542,10 +542,10 @@ class ExchangeOnlineClient:
             # Could be "not found" error - check if group exists
             check = await self.get_distribution_group(identity)
             if check is None:
-                logger.info(f"Distribution group already deleted: {identity}")
+                logger.info("Distribution group already deleted: %s", identity)
                 return True
 
-        logger.error(f"Failed to delete distribution group: {identity}")
+        logger.error("Failed to delete distribution group: %s", identity)
         return False
 
     async def get_distribution_group_members(self, identity: str) -> list[str]:
@@ -608,14 +608,14 @@ class ExchangeOnlineClient:
         result_str = str(result) if result else ""
 
         if "SUCCESS" in result_str:
-            logger.info(f"Added {member} to {identity}")
+            logger.info("Added %s to %s", member, identity)
             return True
 
         if "already a member" in result_str.lower():
-            logger.debug(f"{member} is already a member of {identity}")
+            logger.debug("%s is already a member of %s", member, identity)
             return True
 
-        logger.error(f"Failed to add {member} to {identity}")
+        logger.error("Failed to add %s to %s", member, identity)
         return False
 
     async def remove_distribution_group_member(
@@ -645,13 +645,13 @@ class ExchangeOnlineClient:
         result = self._run_powershell(commands, parse_json=False)
         result_str = str(result) if result else ""
         if "SUCCESS" in result_str:
-            logger.info(f"Removed {member} from {identity}")
+            logger.info("Removed %s from %s", member, identity)
             return True
         if "ALREADY_REMOVED" in result_str:
-            logger.info(f"Member {member} already not in {identity}, skipping")
+            logger.info("Member %s already not in %s, skipping", member, identity)
             return True
 
-        logger.error(f"Failed to remove {member} from {identity}")
+        logger.error("Failed to remove %s from %s", member, identity)
         return False
 
     async def sync_group_members(
@@ -756,11 +756,11 @@ class ExchangeOnlineClient:
 
         # Log results
         for member in added:
-            logger.info(f"Added {member} to {identity}")
+            logger.info("Added %s to %s", member, identity)
         for member in removed:
-            logger.info(f"Removed {member} from {identity}")
+            logger.info("Removed %s from %s", member, identity)
         for error in errors:
-            logger.error(f"Member sync error for {identity}: {error}")
+            logger.error("Member sync error for %s: %s", identity, error)
 
         return added, removed, errors
 
@@ -922,15 +922,18 @@ class ExchangeOnlineClient:
                 permanent_errors.append(error)
 
         if transient_failures:
-            logger.info(f"Retrying {len(transient_failures)} transient failures for {identity}")
+            logger.info("Retrying %d transient failures for %s", len(transient_failures), identity)
 
             for attempt, delay in enumerate(RETRY_DELAYS_SECONDS[:MAX_RETRY_ATTEMPTS]):
                 if not transient_failures:
                     break
 
                 logger.info(
-                    f"Retry attempt {attempt + 1}/{MAX_RETRY_ATTEMPTS} "
-                    f"after {delay}s delay for {len(transient_failures)} members"
+                    "Retry attempt %d/%d after %ds delay for %d members",
+                    attempt + 1,
+                    MAX_RETRY_ATTEMPTS,
+                    delay,
+                    len(transient_failures),
                 )
                 await asyncio.sleep(delay)
 
@@ -951,7 +954,7 @@ class ExchangeOnlineClient:
                     retry_result = self._run_powershell(add_script)
                     # Check for SUCCESS in string or raw dict output
                     if "SUCCESS" in str(retry_result):
-                        logger.info(f"Retry succeeded: Added {member} to {identity}")
+                        logger.info("Retry succeeded: Added %s to %s", member, identity)
                         result["added"].append(member)
                     elif is_transient_error(str(retry_result)):
                         still_failing.append(member)
@@ -987,11 +990,11 @@ class ExchangeOnlineClient:
         result = await asyncio.to_thread(self._run_powershell, commands, parse_json=False)
 
         if result is None:
-            logger.error(f"Failed to set welcome message for {identity}")
+            logger.error("Failed to set welcome message for %s", identity)
             return False
 
         status = "enabled" if enabled else "disabled"
-        logger.info(f"Welcome messages {status} for {identity}")
+        logger.info("Welcome messages %s for %s", status, identity)
         return True
 
     async def set_unified_group_calendar_settings(
@@ -1020,10 +1023,10 @@ class ExchangeOnlineClient:
         result = await asyncio.to_thread(self._run_powershell, commands, parse_json=False)
 
         if result is None:
-            logger.error(f"Failed to set calendar settings for {identity}")
+            logger.error("Failed to set calendar settings for %s", identity)
             return False
 
-        logger.info(f"Calendar auto-subscribe settings applied for {identity}")
+        logger.info("Calendar auto-subscribe settings applied for %s", identity)
         return True
 
     async def close(self) -> None:

--- a/src/sjifire/ispyfire/client.py
+++ b/src/sjifire/ispyfire/client.py
@@ -91,7 +91,7 @@ def _is_rate_limited(response: httpx.Response) -> bool:
 def _log_retry(retry_state) -> None:
     """Log retry attempts."""
     if retry_state.attempt_number > 1:
-        logger.warning(f"Retry attempt {retry_state.attempt_number} after rate limiting")
+        logger.warning("Retry attempt %d after rate limiting", retry_state.attempt_number)
 
 
 class ISpyFireClient:
@@ -176,7 +176,7 @@ class ISpyFireClient:
         response = self.client.request(method, url, **kwargs)
 
         if response.status_code == 429:
-            logger.warning(f"Rate limited (429) on {method} {url}")
+            logger.warning("Rate limited (429) on %s %s", method, url)
 
         return response
 
@@ -189,7 +189,7 @@ class ISpyFireClient:
         if not self.client:
             raise RuntimeError("Client must be used as context manager")
 
-        logger.info(f"Logging in to {self.base_url}")
+        logger.info("Logging in to %s", self.base_url)
 
         response = self.client.post(
             f"{self.base_url}/login",
@@ -200,7 +200,7 @@ class ISpyFireClient:
         )
 
         if response.status_code != 200:
-            logger.error(f"Login failed: {response.status_code}")
+            logger.error("Login failed: %s", response.status_code)
             return False
 
         logger.info("Login successful")
@@ -243,7 +243,7 @@ class ISpyFireClient:
         agency = aid_match.group(1)  # e.g. "sjf3"
         user_id = uid_match.group(1)  # e.g. "svc-automations@sjifire.org"
 
-        logger.debug(f"Central API auth: agency={agency}, user={user_id}")
+        logger.debug("Central API auth: agency=%s, user=%s", agency, user_id)
 
         # Authenticate with central API using PID as password
         self.central_client = httpx.Client(
@@ -263,7 +263,7 @@ class ISpyFireClient:
             return False
 
         if response.status_code != 200:
-            logger.warning(f"Central API login failed: {response.status_code}")
+            logger.warning("Central API login failed: %s", response.status_code)
             return False
 
         data = response.json()
@@ -297,7 +297,7 @@ class ISpyFireClient:
             return
 
         if response.status_code != 200:
-            logger.warning(f"CAD settings request failed: {response.status_code}")
+            logger.warning("CAD settings request failed: %s", response.status_code)
             return
 
         data = response.json()
@@ -306,7 +306,7 @@ class ISpyFireClient:
             settings = results[0]
             self.ispyid = settings.get("ispyid")
             self.leadispyid = settings.get("leadispyid")
-            logger.debug(f"CAD settings: ispyid={self.ispyid}, leadispyid={self.leadispyid}")
+            logger.debug("CAD settings: ispyid=%s, leadispyid=%s", self.ispyid, self.leadispyid)
 
     def _central_request(
         self,
@@ -386,7 +386,7 @@ class ISpyFireClient:
         if params:
             url += "?" + "&".join(params)
 
-        logger.info(f"Fetching people from {url}")
+        logger.info("Fetching people from %s", url)
         try:
             response = self._request("GET", url)
         except RetryError:
@@ -394,12 +394,12 @@ class ISpyFireClient:
             return []
 
         if response.status_code != 200:
-            logger.error(f"Failed to fetch people: {response.status_code}")
+            logger.error("Failed to fetch people: %s", response.status_code)
             return []
 
         data = response.json()
         people = [ISpyFirePerson.from_api(p) for p in data.get("results", [])]
-        logger.info(f"Fetched {len(people)} people from iSpyFire")
+        logger.info("Fetched %d people from iSpyFire", len(people))
         return people
 
     def get_person_by_email(self, email: str) -> ISpyFirePerson | None:
@@ -415,13 +415,13 @@ class ISpyFireClient:
         try:
             response = self._request("GET", url)
         except RetryError:
-            logger.error(f"Failed to fetch person by email after max retries: {email}")
+            logger.error("Failed to fetch person by email after max retries: %s", email)
             return None
 
         if response.status_code == 404:
             return None
         if response.status_code != 200:
-            logger.error(f"Failed to fetch person by email: {response.status_code}")
+            logger.error("Failed to fetch person by email: %s", response.status_code)
             return None
 
         data = response.json()
@@ -451,7 +451,7 @@ class ISpyFireClient:
             return None
 
         if response.status_code not in (200, 201):
-            logger.error(f"Failed to create person: {response.status_code}")
+            logger.error("Failed to create person: %s", response.status_code)
             return None
 
         data = response.json()
@@ -481,11 +481,11 @@ class ISpyFireClient:
                 headers={"Content-Type": "application/json"},
             )
         except RetryError:
-            logger.error(f"Failed to update person after max retries: {person.id}")
+            logger.error("Failed to update person after max retries: %s", person.id)
             return None
 
         if response.status_code != 200:
-            logger.error(f"Failed to update person: {response.status_code}")
+            logger.error("Failed to update person: %s", response.status_code)
             return None
 
         data = response.json()
@@ -524,7 +524,7 @@ class ISpyFireClient:
                 headers={"Content-Type": "application/json"},
             )
             if response.status_code != 200:
-                logger.warning(f"Failed to deactivate iOS push: {response.status_code}")
+                logger.warning("Failed to deactivate iOS push: %s", response.status_code)
                 success = False
         except RetryError:
             logger.warning("Failed to deactivate iOS push after max retries")
@@ -540,7 +540,7 @@ class ISpyFireClient:
                 headers={"Content-Type": "application/json"},
             )
             if response.status_code != 200:
-                logger.warning(f"Failed to deactivate GCM push: {response.status_code}")
+                logger.warning("Failed to deactivate GCM push: %s", response.status_code)
                 success = False
         except RetryError:
             logger.warning("Failed to deactivate GCM push after max retries")
@@ -553,14 +553,14 @@ class ISpyFireClient:
             try:
                 response = self._request("GET", url)
                 if response.status_code != 200:
-                    logger.warning(f"Failed to clear notifications: {response.status_code}")
+                    logger.warning("Failed to clear notifications: %s", response.status_code)
                     success = False
             except RetryError:
                 logger.warning("Failed to clear notifications after max retries")
                 success = False
 
         if success:
-            logger.info(f"Logged out push notifications for {email}")
+            logger.info("Logged out push notifications for %s", email)
         return success
 
     def remove_all_devices(self, email: str) -> bool:
@@ -583,10 +583,10 @@ class ISpyFireClient:
             return False
 
         if response.status_code != 200:
-            logger.warning(f"Failed to remove devices: {response.status_code}")
+            logger.warning("Failed to remove devices: %s", response.status_code)
             return False
 
-        logger.info(f"Removed all devices for {email}")
+        logger.info("Removed all devices for %s", email)
         return True
 
     def logout_mobile_devices(self, person_id: str) -> bool:
@@ -609,10 +609,10 @@ class ISpyFireClient:
             return False
 
         if response.status_code != 200:
-            logger.warning(f"Failed to logout mobile devices: {response.status_code}")
+            logger.warning("Failed to logout mobile devices: %s", response.status_code)
             return False
 
-        logger.info(f"Logged out mobile devices for person {person_id}")
+        logger.info("Logged out mobile devices for person %s", person_id)
         return True
 
     def send_invite_email(self, email: str) -> bool:
@@ -635,14 +635,14 @@ class ISpyFireClient:
                 headers={"Content-Type": "application/json"},
             )
         except RetryError:
-            logger.error(f"Failed to send invite email after max retries: {email}")
+            logger.error("Failed to send invite email after max retries: %s", email)
             return False
 
         if response.status_code != 200:
-            logger.warning(f"Failed to send invite email: {response.status_code}")
+            logger.warning("Failed to send invite email: %s", response.status_code)
             return False
 
-        logger.info(f"Sent invite email to {email}")
+        logger.info("Sent invite email to %s", email)
         return True
 
     def deactivate_person(
@@ -679,14 +679,14 @@ class ISpyFireClient:
                 headers={"Content-Type": "application/json"},
             )
         except RetryError:
-            logger.error(f"Failed to deactivate person after max retries: {person_id}")
+            logger.error("Failed to deactivate person after max retries: %s", person_id)
             return False
 
         if response.status_code != 200:
-            logger.error(f"Failed to deactivate person: {response.status_code}")
+            logger.error("Failed to deactivate person: %s", response.status_code)
             return False
 
-        logger.info(f"Deactivated person {person_id}")
+        logger.info("Deactivated person %s", person_id)
         return True
 
     def reactivate_person(self, person_id: str, email: str | None = None) -> bool:
@@ -712,21 +712,21 @@ class ISpyFireClient:
                 headers={"Content-Type": "application/json"},
             )
         except RetryError:
-            logger.error(f"Failed to reactivate person after max retries: {person_id}")
+            logger.error("Failed to reactivate person after max retries: %s", person_id)
             return False
 
         if response.status_code != 200:
-            logger.error(f"Failed to reactivate person: {response.status_code}")
+            logger.error("Failed to reactivate person: %s", response.status_code)
             return False
 
-        logger.info(f"Reactivated person {person_id}")
+        logger.info("Reactivated person %s", person_id)
 
         # Send password reset email if email provided
         if email:
             if self.send_invite_email(email):
-                logger.info(f"Sent password reset email to {email}")
+                logger.info("Sent password reset email to %s", email)
             else:
-                logger.warning(f"Failed to send password reset email to {email}")
+                logger.warning("Failed to send password reset email to %s", email)
 
         return True
 
@@ -755,9 +755,9 @@ class ISpyFireClient:
         # Send invite email
         if person.email:
             if self.send_invite_email(person.email):
-                logger.info(f"Sent invite email to {person.email}")
+                logger.info("Sent invite email to %s", person.email)
             else:
-                logger.warning(f"Failed to send invite email to {person.email}")
+                logger.warning("Failed to send invite email to %s", person.email)
 
         return result
 
@@ -777,7 +777,7 @@ class ISpyFireClient:
         now = int(time.time())
         after = now - (days * 24 * 60 * 60)
         raw = self.search_calls_raw(after=after, before=now)
-        logger.info(f"Search returned {len(raw)} calls for last {days} days")
+        logger.info("Search returned %d calls for last %d days", len(raw), days)
 
         calls: list[DispatchCall] = []
         for entry in raw:
@@ -812,7 +812,7 @@ class ISpyFireClient:
         url = f"{self.CENTRAL_API_BASE}/calls/details/{self.ispyid}/id/{call_id}"
         response = self._central_request("GET", url)
         if not response or response.status_code != 200:
-            logger.error(f"Failed to fetch call details: {call_id}")
+            logger.error("Failed to fetch call details: %s", call_id)
             return None
 
         data = response.json()
@@ -903,7 +903,7 @@ class ISpyFireClient:
         url = f"{self.CENTRAL_API_BASE}/logging/calldetails/callid/{call_id}"
         response = self._central_request("GET", url)
         if not response or response.status_code != 200:
-            logger.error(f"Failed to fetch call log: {call_id}")
+            logger.error("Failed to fetch call log: %s", call_id)
             return []
 
         data = response.json()
@@ -949,7 +949,7 @@ class ISpyFireClient:
         )
         if not response or response.status_code != 200:
             status = response.status_code if response else "no response"
-            logger.error(f"Search calls failed: {status}")
+            logger.error("Search calls failed: %s", status)
             return []
 
         data = response.json()

--- a/src/sjifire/ispyfire/sync.py
+++ b/src/sjifire/ispyfire/sync.py
@@ -218,12 +218,13 @@ def compare_entra_to_ispyfire(
     operational_users = [u for u in managed_users if is_operational(u)]
     comparison.entra_operational = operational_users
 
-    logger.info(f"Found {len(operational_users)} operational @{domain} users in Entra")
+    logger.info("Found %d operational @%s users in Entra", len(operational_users), domain)
     if comparison.skipped_no_operational:
         logger.info(
-            f"Skipped {len(comparison.skipped_no_operational)} users without operational positions"
+            "Skipped %d users without operational positions",
+            len(comparison.skipped_no_operational),
         )
-    logger.info(f"Found {len(ispyfire_people)} people in iSpyFire")
+    logger.info("Found %d people in iSpyFire", len(ispyfire_people))
 
     # Build lookup by email for iSpyFire people (only managed domain)
     ispyfire_by_email: dict[str, ISpyFirePerson] = {}
@@ -247,7 +248,7 @@ def compare_entra_to_ispyfire(
     for user in operational_users:
         user_email = normalize_email(user.email)
         if not user_email:
-            logger.warning(f"Skipping user without email: {user.display_name}")
+            logger.warning("Skipping user without email: %s", user.display_name)
             continue
 
         # Find matching iSpyFire person by email (managed domain only)
@@ -261,7 +262,9 @@ def compare_entra_to_ispyfire(
             if person_by_name is not None:
                 # Duplicate exists with different email - skip adding
                 logger.debug(
-                    f"Skipping {user.display_name}: duplicate exists as {person_by_name.email}"
+                    "Skipping %s: duplicate exists as %s",
+                    user.display_name,
+                    person_by_name.email,
                 )
                 continue
 
@@ -294,12 +297,12 @@ def compare_entra_to_ispyfire(
             comparison.to_remove.append(person)
 
     logger.info("Comparison complete:")
-    logger.info(f"  - Matched: {len(comparison.matched)}")
-    logger.info(f"  - To add: {len(comparison.to_add)}")
-    logger.info(f"  - To update: {len(comparison.to_update)}")
-    logger.info(f"  - To remove: {len(comparison.to_remove)}")
+    logger.info("  - Matched: %d", len(comparison.matched))
+    logger.info("  - To add: %d", len(comparison.to_add))
+    logger.info("  - To update: %d", len(comparison.to_update))
+    logger.info("  - To remove: %d", len(comparison.to_remove))
     if comparison.skipped_no_phone:
-        logger.info(f"  - Skipped (no phone): {len(comparison.skipped_no_phone)}")
+        logger.info("  - Skipped (no phone): %d", len(comparison.skipped_no_phone))
 
     return comparison
 

--- a/src/sjifire/neris/client.py
+++ b/src/sjifire/neris/client.py
@@ -149,7 +149,7 @@ class NerisClient:
             neris_id: Entity ID (defaults to configured entity)
         """
         neris_id = neris_id or self.entity_id
-        logger.info(f"Fetching entity {neris_id}")
+        logger.info("Fetching entity %s", neris_id)
         return self.api.get_entity(neris_id)
 
     def list_incidents(
@@ -175,7 +175,7 @@ class NerisClient:
             RuntimeError: If the API returns an error response.
         """
         neris_id = neris_id or self.entity_id
-        logger.info(f"Listing incidents for {neris_id}")
+        logger.info("Listing incidents for %s", neris_id)
         result = self.api.list_incidents(
             neris_id_entity=neris_id,
             page_size=page_size,
@@ -210,7 +210,7 @@ class NerisClient:
             if not cursor or not incidents:
                 break
 
-        logger.info(f"Fetched {len(all_incidents)} total incidents")
+        logger.info("Fetched %d total incidents", len(all_incidents))
         return all_incidents
 
     def get_pending_incidents(self, *, neris_id: str | None = None) -> list[dict]:
@@ -371,5 +371,5 @@ class NerisClient:
             "action": "patch",
             "properties": properties,
         }
-        logger.info(f"Patching incident {neris_id_incident}")
+        logger.info("Patching incident %s", neris_id_incident)
         return self.api.patch_incident(neris_id, neris_id_incident, body)

--- a/src/sjifire/ops/chat/centrifugo.py
+++ b/src/sjifire/ops/chat/centrifugo.py
@@ -58,9 +58,7 @@ async def publish(channel: str, event: str, data: dict) -> None:
         req = PublishRequest(channel=channel, data={"event": event, **data})
         await client.publish(req)
     except Exception:
-        logger.error(
-            "Centrifugo publish failed (channel=%s, event=%s)", channel, event, exc_info=True
-        )
+        logger.exception("Centrifugo publish failed (channel=%s, event=%s)", channel, event)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sjifire/ops/dispatch/store.py
+++ b/src/sjifire/ops/dispatch/store.py
@@ -355,7 +355,7 @@ class DispatchStore(CosmosStore):
         try:
             doc.analysis = await enrich_dispatch(doc)
         except Exception:
-            logger.error("Enrichment failed for %s", doc.long_term_call_id, exc_info=True)
+            logger.exception("Enrichment failed for %s", doc.long_term_call_id)
         return doc
 
     async def store_call(self, call: DispatchCall) -> DispatchCallDocument:

--- a/src/sjifire/scripts/aladtec_list.py
+++ b/src/sjifire/scripts/aladtec_list.py
@@ -55,10 +55,10 @@ def run_list(output_format: str = "table") -> int:
             logger.error("No members found")
             return 1
 
-        logger.info(f"Found {len(members)} members\n")
+        logger.info("Found %d members\n", len(members))
 
     except Exception as e:
-        logger.error(f"Failed to fetch members: {e}")
+        logger.error("Failed to fetch members: %s", e)
         return 1
 
     # Convert to dicts and format positions as comma-delimited

--- a/src/sjifire/scripts/analyze_mappings.py
+++ b/src/sjifire/scripts/analyze_mappings.py
@@ -86,7 +86,7 @@ async def analyze_mappings(verbose: bool = False) -> None:
                 return
             members = scraper.get_members(include_inactive=True)
     except Exception as e:
-        logger.error(f"Failed to fetch Aladtec members: {e}")
+        logger.error("Failed to fetch Aladtec members: %s", e)
         return
 
     # Extract unique positions and count members per position
@@ -99,7 +99,7 @@ async def analyze_mappings(verbose: bool = False) -> None:
             position_members[member.employee_type].append(member.display_name)
 
     positions = sorted(position_members.keys())
-    logger.info(f"Found {len(positions)} unique positions across {len(members)} members")
+    logger.info("Found %d unique positions across %d members", len(positions), len(members))
 
     # Fetch Entra groups
     logger.info("")
@@ -109,7 +109,7 @@ async def analyze_mappings(verbose: bool = False) -> None:
         group_manager = EntraGroupManager()
         all_groups = await group_manager.get_groups()
     except Exception as e:
-        logger.error(f"Failed to fetch Entra groups: {e}")
+        logger.error("Failed to fetch Entra groups: %s", e)
         return
 
     # Categorize groups
@@ -119,10 +119,10 @@ async def analyze_mappings(verbose: bool = False) -> None:
         g for g in all_groups if g.group_type not in (GroupType.SECURITY, GroupType.MICROSOFT_365)
     ]
 
-    logger.info(f"Found {len(all_groups)} total groups:")
-    logger.info(f"  - Security groups: {len(security_groups)}")
-    logger.info(f"  - Microsoft 365 groups: {len(m365_groups)}")
-    logger.info(f"  - Other (distribution, etc.): {len(other_groups)}")
+    logger.info("Found %d total groups:", len(all_groups))
+    logger.info("  - Security groups: %d", len(security_groups))
+    logger.info("  - Microsoft 365 groups: %d", len(m365_groups))
+    logger.info("  - Other (distribution, etc.): %d", len(other_groups))
 
     # Print all groups
     logger.info("")
@@ -135,7 +135,7 @@ async def analyze_mappings(verbose: bool = False) -> None:
     logger.info("-" * 40)
     for group in sorted(security_groups, key=lambda g: g.display_name):
         desc = f" - {group.description[:50]}..." if group.description else ""
-        logger.info(f"  {group.display_name}{desc}")
+        logger.info("  %s%s", group.display_name, desc)
 
     logger.info("")
     logger.info("Microsoft 365 Groups:")
@@ -143,14 +143,14 @@ async def analyze_mappings(verbose: bool = False) -> None:
     for group in sorted(m365_groups, key=lambda g: g.display_name):
         desc = f" - {group.description[:50]}..." if group.description else ""
         mail = f" ({group.mail})" if group.mail else ""
-        logger.info(f"  {group.display_name}{mail}{desc}")
+        logger.info("  %s%s%s", group.display_name, mail, desc)
 
     if other_groups:
         logger.info("")
         logger.info("Other Groups (Distribution Lists, etc.):")
         logger.info("-" * 40)
         for group in sorted(other_groups, key=lambda g: g.display_name):
-            logger.info(f"  {group.display_name} ({group.group_type.value})")
+            logger.info("  %s (%s)", group.display_name, group.group_type.value)
 
     # Print all positions
     logger.info("")
@@ -160,10 +160,10 @@ async def analyze_mappings(verbose: bool = False) -> None:
     logger.info("")
     for pos in positions:
         count = len(position_members[pos])
-        logger.info(f"  {pos} ({count} member{'s' if count != 1 else ''})")
+        logger.info("  %s (%d member%s)", pos, count, "s" if count != 1 else "")
         if verbose:
             for name in sorted(position_members[pos]):
-                logger.info(f"    - {name}")
+                logger.info("    - %s", name)
 
     # Analyze mappings
     logger.info("")
@@ -194,10 +194,10 @@ async def analyze_mappings(verbose: bool = False) -> None:
     for pos, matches in matched_positions:
         member_count = len(position_members[pos])
         logger.info("")
-        logger.info(f"  {pos} ({member_count} members)")
+        logger.info("  %s (%d members)", pos, member_count)
         for group, reason in matches:
             gtype = "Security" if group.group_type == GroupType.SECURITY else "M365"
-            logger.info(f"    -> {group.display_name} [{gtype}] ({reason})")
+            logger.info("    -> %s [%s] (%s)", group.display_name, gtype, reason)
 
     # Print positions without matches (GAPS)
     logger.info("")
@@ -208,7 +208,7 @@ async def analyze_mappings(verbose: bool = False) -> None:
     if unmatched_positions:
         for pos in unmatched_positions:
             member_count = len(position_members[pos])
-            logger.info(f"  {pos} ({member_count} members) - NO MATCHING GROUP")
+            logger.info("  %s (%d members) - NO MATCHING GROUP", pos, member_count)
     else:
         logger.info("  All positions have potential group matches!")
 
@@ -222,7 +222,7 @@ async def analyze_mappings(verbose: bool = False) -> None:
     if unused_groups:
         for group in sorted(unused_groups, key=lambda g: g.display_name):
             gtype = "Security" if group.group_type == GroupType.SECURITY else "M365"
-            logger.info(f"  {group.display_name} [{gtype}]")
+            logger.info("  %s [%s]", group.display_name, gtype)
     else:
         logger.info("  All groups have potential position matches!")
 
@@ -232,13 +232,13 @@ async def analyze_mappings(verbose: bool = False) -> None:
     logger.info("SUMMARY")
     logger.info("=" * 60)
     logger.info("")
-    logger.info(f"Aladtec Positions: {len(positions)}")
-    logger.info(f"  - With suggested mappings: {len(matched_positions)}")
-    logger.info(f"  - Without matches (need new groups): {len(unmatched_positions)}")
+    logger.info("Aladtec Positions: %d", len(positions))
+    logger.info("  - With suggested mappings: %d", len(matched_positions))
+    logger.info("  - Without matches (need new groups): %d", len(unmatched_positions))
     logger.info("")
-    logger.info(f"Entra Groups (Security + M365): {len(mappable_groups)}")
-    logger.info(f"  - Matched to positions: {len(used_groups)}")
-    logger.info(f"  - Not matched (may be unrelated): {len(unused_groups)}")
+    logger.info("Entra Groups (Security + M365): %d", len(mappable_groups))
+    logger.info("  - Matched to positions: %d", len(used_groups))
+    logger.info("  - Not matched (may be unrelated): %d", len(unused_groups))
 
 
 def main():

--- a/src/sjifire/scripts/compare_group_memberships.py
+++ b/src/sjifire/scripts/compare_group_memberships.py
@@ -32,7 +32,7 @@ async def compare_memberships(
     logger.info("=" * 60)
     logger.info("Group Membership Comparison")
     logger.info("=" * 60)
-    logger.info(f"Strategies: {', '.join(strategy_names)}")
+    logger.info("Strategies: %s", ", ".join(strategy_names))
 
     # Fetch Aladtec members
     logger.info("")
@@ -45,10 +45,10 @@ async def compare_memberships(
                 return
             members = scraper.get_members(include_inactive=False)
     except Exception as e:
-        logger.error(f"Failed to fetch Aladtec members: {e}")
+        logger.error("Failed to fetch Aladtec members: %s", e)
         return
 
-    logger.info(f"Found {len(members)} active members")
+    logger.info("Found %d active members", len(members))
 
     # Build expected memberships from strategies
     # expected_memberships[group_email] = set of member emails
@@ -117,7 +117,7 @@ async def compare_memberships(
                             actual_memberships[group_email].add(user.upn.lower())
                 continue
         except Exception as e:
-            logger.debug(f"Error checking M365 for {group_email}: {e}")
+            logger.debug("Error checking M365 for %s: %s", group_email, e)
 
         # Try Exchange
         try:
@@ -128,7 +128,7 @@ async def compare_memberships(
                 actual_memberships[group_email] = {e.lower() for e in member_emails}
                 continue
         except Exception as e:
-            logger.debug(f"Error checking Exchange for {group_email}: {e}")
+            logger.debug("Error checking Exchange for %s: %s", group_email, e)
 
         # Group doesn't exist
         group_types[group_email] = "NOT FOUND"
@@ -155,23 +155,23 @@ async def compare_memberships(
         extra = actual - expected
 
         logger.info("")
-        logger.info(f"{display_name} ({group_email}):")
-        logger.info(f"  Type: {group_type}")
-        logger.info(f"  Expected: {len(expected)} members")
-        logger.info(f"  Actual:   {len(actual)} members")
+        logger.info("%s (%s):", display_name, group_email)
+        logger.info("  Type: %s", group_type)
+        logger.info("  Expected: %d members", len(expected))
+        logger.info("  Actual:   %d members", len(actual))
 
         if missing:
-            logger.info(f"  MISSING ({len(missing)}):")
+            logger.info("  MISSING (%d):", len(missing))
             for email in sorted(missing):
                 name = email_to_name.get(email, email)
-                logger.info(f"    - {name} ({email})")
+                logger.info("    - %s (%s)", name, email)
             total_missing += len(missing)
 
         if extra:
-            logger.info(f"  EXTRA ({len(extra)}):")
+            logger.info("  EXTRA (%d):", len(extra))
             for email in sorted(extra):
                 name = email_to_name.get(email, email)
-                logger.info(f"    - {name} ({email})")
+                logger.info("    - %s (%s)", name, email)
             total_extra += len(extra)
 
         if not missing and not extra and group_type != "NOT FOUND":
@@ -186,10 +186,10 @@ async def compare_memberships(
     logger.info("SUMMARY")
     logger.info("=" * 60)
     logger.info("")
-    logger.info(f"Groups analyzed: {len(expected_memberships)}")
-    logger.info(f"Groups with discrepancies: {groups_with_issues}")
-    logger.info(f"Total missing memberships: {total_missing}")
-    logger.info(f"Total extra memberships: {total_extra}")
+    logger.info("Groups analyzed: %d", len(expected_memberships))
+    logger.info("Groups with discrepancies: %d", groups_with_issues)
+    logger.info("Total missing memberships: %d", total_missing)
+    logger.info("Total extra memberships: %d", total_extra)
 
 
 def main():

--- a/src/sjifire/scripts/duty_calendar_sync.py
+++ b/src/sjifire/scripts/duty_calendar_sync.py
@@ -154,16 +154,21 @@ def main() -> int:
             logger.error(str(e))
             return 1
 
-        logger.info(f"Deleting On Duty events from {args.mailbox} for {start_date} to {end_date}")
+        logger.info(
+            "Deleting On Duty events from %s for %s to %s",
+            args.mailbox,
+            start_date,
+            end_date,
+        )
 
         calendar_sync = DutyCalendarSync(mailbox=args.mailbox)
         result = calendar_sync.delete_date_range(start_date, end_date, dry_run=args.dry_run)
 
-        logger.info(f"Delete complete: {result}")
+        logger.info("Delete complete: %s", result)
 
         if result.errors:
             for error in result.errors:
-                logger.error(f"  Error: {error}")
+                logger.error("  Error: %s", error)
             return 1
 
         return 0
@@ -177,7 +182,7 @@ def main() -> int:
             logger.error(str(e))
             return 1
 
-        logger.info(f"Inspecting calendar {args.mailbox} for {start_date} to {end_date}")
+        logger.info("Inspecting calendar %s for %s to %s", args.mailbox, start_date, end_date)
 
         calendar_sync = DutyCalendarSync(mailbox=args.mailbox)
 
@@ -222,7 +227,7 @@ def main() -> int:
         last_day_num = calendar.monthrange(end_year, end_month)[1]
         end_date = date(end_year, end_month, last_day_num)
 
-    logger.info(f"Date range: {start_date} to {end_date}")
+    logger.info("Date range: %s to %s", start_date, end_date)
 
     # Step 1: Fetch schedules from Aladtec
     logger.info("Fetching schedule from Aladtec...")
@@ -239,24 +244,24 @@ def main() -> int:
         # Still continue to sync what we have
         schedules = []
 
-    logger.info(f"Retrieved {len(schedules)} days of schedule data")
+    logger.info("Retrieved %d days of schedule data", len(schedules))
 
     # Save schedule for personal-calendar-sync to reuse
     if args.save_schedule:
         save_schedules(schedules, args.save_schedule)
 
     # Step 2: Sync to calendar
-    logger.info(f"Syncing to calendar: {args.mailbox}")
+    logger.info("Syncing to calendar: %s", args.mailbox)
 
     calendar_sync = DutyCalendarSync(mailbox=args.mailbox)
     result = calendar_sync.sync(schedules, dry_run=args.dry_run, force=args.force)
 
     # Report results
-    logger.info(f"Sync complete: {result}")
+    logger.info("Sync complete: %s", result)
 
     if result.errors:
         for error in result.errors:
-            logger.error(f"  Error: {error}")
+            logger.error("  Error: %s", error)
         return 1
 
     return 0

--- a/src/sjifire/scripts/entra_audit.py
+++ b/src/sjifire/scripts/entra_audit.py
@@ -241,14 +241,14 @@ async def run_audit(skip_entra: bool = False) -> int:
                 return 1
             members = scraper.get_members(include_inactive=True)
     except Exception as e:
-        logger.error(f"Failed to fetch Aladtec members: {e}")
+        logger.error("Failed to fetch Aladtec members: %s", e)
         return 1
 
     if not members:
         logger.error("No members found in Aladtec")
         return 1
 
-    logger.info(f"Found {len(members)} members in Aladtec")
+    logger.info("Found %d members in Aladtec", len(members))
 
     # Check for missing data
     print("\n" + "=" * 60)
@@ -291,11 +291,11 @@ async def run_audit(skip_entra: bool = False) -> int:
         logger.info("Fetching users from Entra ID...")
         try:
             entra_users = await get_entra_users()
-            logger.info(f"Found {len(entra_users)} users in Entra ID")
+            logger.info("Found %d users in Entra ID", len(entra_users))
 
             # Filter to just org domain accounts for reporting
             org_users = [u for u in entra_users if u.get("upn", "").endswith(f"@{domain}")]
-            logger.info(f"Found {len(org_users)} @{domain} accounts in Entra ID")
+            logger.info("Found %d @%s accounts in Entra ID", len(org_users), domain)
 
             members_not_in_entra, entra_not_in_aladtec = compare_systems(members, entra_users)
 
@@ -342,7 +342,7 @@ async def run_audit(skip_entra: bool = False) -> int:
                 )
 
         except Exception as e:
-            logger.error(f"Failed to fetch Entra ID users: {e}")
+            logger.error("Failed to fetch Entra ID users: %s", e)
             print("\n  (Entra ID comparison skipped due to error)")
 
     # Summary

--- a/src/sjifire/scripts/entra_user_sync.py
+++ b/src/sjifire/scripts/entra_user_sync.py
@@ -48,7 +48,7 @@ async def cleanup_disabled_licenses(dry_run: bool = False) -> int:
 
     # Filter to only disabled users
     disabled_users = [u for u in all_users if not u.account_enabled]
-    logger.info(f"Found {len(disabled_users)} disabled users")
+    logger.info("Found %d disabled users", len(disabled_users))
 
     if not disabled_users:
         logger.info("No disabled users found - nothing to do")
@@ -59,28 +59,28 @@ async def cleanup_disabled_licenses(dry_run: bool = False) -> int:
 
     for user in disabled_users:
         display = user.display_name or user.upn or user.id
-        logger.info(f"Checking {display}...")
+        logger.info("Checking %s...", display)
 
         # Get current licenses
         licenses = await user_manager.get_user_licenses(user.id)
 
         if not licenses:
-            logger.info(f"  {display}: no licenses to remove")
+            logger.info("  %s: no licenses to remove", display)
             results["skipped"].append({"user": display, "reason": "no licenses"})
             continue
 
-        logger.info(f"  {display}: has {len(licenses)} license(s)")
+        logger.info("  %s: has %d license(s)", display, len(licenses))
 
         if dry_run:
-            logger.info(f"  Would remove {len(licenses)} license(s) from {display}")
+            logger.info("  Would remove %d license(s) from %s", len(licenses), display)
             results["cleaned"].append({"user": display, "licenses": len(licenses)})
         else:
             success = await user_manager.remove_all_licenses(user.id)
             if success:
-                logger.info(f"  Removed {len(licenses)} license(s) from {display}")
+                logger.info("  Removed %d license(s) from %s", len(licenses), display)
                 results["cleaned"].append({"user": display, "licenses": len(licenses)})
             else:
-                logger.error(f"  Failed to remove licenses from {display}")
+                logger.error("  Failed to remove licenses from %s", display)
                 results["errors"].append({"user": display, "error": "API call failed"})
 
     # Summary
@@ -88,9 +88,9 @@ async def cleanup_disabled_licenses(dry_run: bool = False) -> int:
     logger.info("=" * 50)
     logger.info("Results")
     logger.info("=" * 50)
-    logger.info(f"Licenses removed: {len(results['cleaned'])} users")
-    logger.info(f"Skipped (no licenses): {len(results['skipped'])} users")
-    logger.info(f"Errors: {len(results['errors'])} users")
+    logger.info("Licenses removed: %d users", len(results["cleaned"]))
+    logger.info("Skipped (no licenses): %d users", len(results["skipped"]))
+    logger.info("Errors: %d users", len(results["errors"]))
 
     return 0 if not results["errors"] else 1
 
@@ -140,7 +140,10 @@ async def run_import(
         active_count = sum(1 for m in members if m.is_active)
         inactive_count = len(members) - active_count
         logger.info(
-            f"Found {len(members)} members ({active_count} active, {inactive_count} inactive)"
+            "Found %d members (%d active, %d inactive)",
+            len(members),
+            active_count,
+            inactive_count,
         )
 
         # Filter to individual if specified (by email)
@@ -149,13 +152,13 @@ async def run_import(
             matching = [m for m in members if m.email and m.email.lower() == individual_lower]
 
             if not matching:
-                logger.error(f"No member found with email '{individual}'")
+                logger.error("No member found with email '%s'", individual)
                 return 1
             members = matching
-            logger.info(f"Filtering to individual: {members[0].display_name}")
+            logger.info("Filtering to individual: %s", members[0].display_name)
 
     except Exception as e:
-        logger.error(f"Failed to fetch Aladtec members: {e}")
+        logger.error("Failed to fetch Aladtec members: %s", e)
         return 1
 
     # Backup Entra data before making changes (automatic, not optional)
@@ -168,10 +171,10 @@ async def run_import(
             user_manager = EntraUserManager()
             entra_users = await user_manager.get_users(include_disabled=True)
             entra_backup = backup_entra_users(entra_users)
-            logger.info(f"Entra backup: {entra_backup}")
+            logger.info("Entra backup: %s", entra_backup)
 
         except Exception as e:
-            logger.error(f"Failed to create Entra backup: {e}")
+            logger.error("Failed to create Entra backup: %s", e)
             return 1
 
     # Import to Entra ID
@@ -187,7 +190,7 @@ async def run_import(
         )
 
     except Exception as e:
-        logger.error(f"Failed to import to Entra ID: {e}")
+        logger.error("Failed to import to Entra ID: %s", e)
         return 1
 
     # Output results
@@ -199,17 +202,17 @@ async def run_import(
     if output_json:
         print(json.dumps(asdict(result), indent=2))
     else:
-        logger.info(f"Created:  {len(result.created)}")
-        logger.info(f"Updated:  {len(result.updated)}")
-        logger.info(f"Disabled: {len(result.disabled)}")
-        logger.info(f"Skipped:  {len(result.skipped)}")
-        logger.info(f"Errors:   {len(result.errors)}")
+        logger.info("Created:  %d", len(result.created))
+        logger.info("Updated:  %d", len(result.updated))
+        logger.info("Disabled: %d", len(result.disabled))
+        logger.info("Skipped:  %d", len(result.skipped))
+        logger.info("Errors:   %d", len(result.errors))
 
         if result.errors:
             logger.info("")
             logger.info("Errors:")
             for error in result.errors:
-                logger.info(f"  - {error['member']}: {error['error']}")
+                logger.info("  - %s: %s", error["member"], error["error"])
 
         # Show interesting skips (not "no changes needed")
         interesting_skips = [s for s in result.skipped if s.get("reason") != "no changes needed"]
@@ -217,7 +220,7 @@ async def run_import(
             logger.info("")
             logger.info("Skipped:")
             for skip in interesting_skips:
-                logger.info(f"  - {skip['member']}: {skip['reason']}")
+                logger.info("  - %s: %s", skip["member"], skip["reason"])
 
     return 0 if not result.errors else 1
 

--- a/src/sjifire/scripts/ispyfire_sync.py
+++ b/src/sjifire/scripts/ispyfire_sync.py
@@ -70,7 +70,7 @@ def backup_ispyfire_people(people: list, backup_dir: Path) -> Path:
     with backup_file.open("w") as f:
         json.dump(data, f, indent=2)
 
-    logger.info(f"Backed up {len(people)} people to {backup_file}")
+    logger.info("Backed up %d people to %s", len(people), backup_file)
     return backup_file
 
 
@@ -194,7 +194,7 @@ async def run_sync(
     logger.info("Fetching Entra ID employees...")
     user_manager = EntraUserManager()
     entra_users = await user_manager.get_employees()
-    logger.info(f"Fetched {len(entra_users)} employees from Entra ID")
+    logger.info("Fetched %d employees from Entra ID", len(entra_users))
 
     # Filter to single user if specified
     if single_email:
@@ -203,7 +203,7 @@ async def run_sync(
         if not entra_users:
             print(f"Error: User not found in Entra ID: {single_email}")
             return 1
-        logger.info(f"Filtering to single user: {single_email}")
+        logger.info("Filtering to single user: %s", single_email)
 
     # Get iSpyFire people (include inactive and deleted to prevent duplicates)
     logger.info("Fetching iSpyFire people...")
@@ -238,28 +238,29 @@ async def run_sync(
             existing = ispy_client.get_person_by_email(user.email) if user.email else None
             if existing:
                 logger.info(
-                    f"Found existing person for {user.email}, reactivating instead of creating"
+                    "Found existing person for %s, reactivating instead of creating",
+                    user.email,
                 )
                 if not existing.is_active:
                     if ispy_client.reactivate_person(existing.id, email=existing.email):
-                        logger.info(f"  Reactivated: {existing.display_name}")
+                        logger.info("  Reactivated: %s", existing.display_name)
                     else:
-                        logger.error(f"  Failed to reactivate: {existing.display_name}")
+                        logger.error("  Failed to reactivate: %s", existing.display_name)
                 else:
-                    logger.info(f"  Already active: {existing.display_name}")
+                    logger.info("  Already active: %s", existing.display_name)
                 continue
 
             person = entra_user_to_ispyfire_person(user)
-            logger.info(f"Creating: {person.display_name}")
+            logger.info("Creating: %s", person.display_name)
             result = ispy_client.create_and_invite(person)
             if result:
-                logger.info(f"  Created with ID: {result.id}")
+                logger.info("  Created with ID: %s", result.id)
             else:
                 logger.error("  Failed to create")
 
         # Update existing people
         for user, person in comparison.to_update:
-            logger.info(f"Updating: {person.display_name}")
+            logger.info("Updating: %s", person.display_name)
             # Update fields from Entra
             if user.first_name:
                 person.first_name = user.first_name
@@ -286,7 +287,7 @@ async def run_sync(
             if not person.is_active
         ]
         for person in to_reactivate:
-            logger.info(f"Reactivating: {person.display_name}")
+            logger.info("Reactivating: %s", person.display_name)
             if ispy_client.reactivate_person(person.id, email=person.email):
                 logger.info("  Reactivated successfully")
             else:
@@ -294,7 +295,7 @@ async def run_sync(
 
         # Deactivate removed people
         for person in comparison.to_remove:
-            logger.info(f"Deactivating: {person.display_name}")
+            logger.info("Deactivating: %s", person.display_name)
             if ispy_client.deactivate_person(person.id, email=person.email):
                 logger.info("  Deactivated successfully")
             else:

--- a/src/sjifire/scripts/m365_group_scan.py
+++ b/src/sjifire/scripts/m365_group_scan.py
@@ -183,7 +183,7 @@ async def get_all_m365_groups(
     logger.debug("Fetching member counts, drive info, and conversations...")
     group_list = []
     for i, g in enumerate(groups):
-        logger.debug(f"  [{i + 1}/{len(groups)}] {g.display_name}")
+        logger.debug("  [%d/%d] %s", i + 1, len(groups), g.display_name)
         member_count = await get_group_member_count(client, g.id)
         drive_info = await get_group_drive_info(client, g.id)
         convo_info = await get_group_conversations_info(client, g.id)
@@ -567,7 +567,7 @@ async def get_drive_contents(client, drive_id: str, item_id: str = "root") -> li
                         sub["name"] = f"{item.name}/{sub['name']}"
                         items.append(sub)
     except Exception as e:
-        logger.debug(f"Error getting drive contents: {e}")
+        logger.debug("Error getting drive contents: %s", e)
     return items
 
 
@@ -596,7 +596,7 @@ async def get_site_pages(client, group_id: str) -> list[dict]:
                     ]
                 )
     except Exception as e:
-        logger.debug(f"Error getting site pages: {e}")
+        logger.debug("Error getting site pages: %s", e)
     return pages
 
 
@@ -618,7 +618,7 @@ async def get_email_history(client, group_id: str) -> list[dict]:
                 ]
             )
     except Exception as e:
-        logger.debug(f"Error getting conversations: {e}")
+        logger.debug("Error getting conversations: %s", e)
     return emails
 
 
@@ -715,7 +715,7 @@ async def run_deep_scan(group_names: list[str] | None, scan_all: bool) -> None:
     print(f"Scanning {len(groups)} groups...\n")
 
     for i, group in enumerate(groups):
-        logger.debug(f"[{i + 1}/{len(groups)}] Scanning {group['display_name']}...")
+        logger.debug("[%d/%d] Scanning %s...", i + 1, len(groups), group["display_name"])
 
         # Get drive ID first
         drive_info = await get_group_drive_info(client, group["id"])

--- a/src/sjifire/scripts/ms_group_sync.py
+++ b/src/sjifire/scripts/ms_group_sync.py
@@ -163,7 +163,7 @@ class UnifiedGroupSyncManager:
             self._entra_users_cache = [
                 u for u in all_users if u.email and u.email.lower().endswith(f"@{self.domain}")
             ]
-            logger.info(f"Loaded {len(self._entra_users_cache)} Entra users for group sync")
+            logger.info("Loaded %d Entra users for group sync", len(self._entra_users_cache))
         return self._entra_users_cache
 
     async def get_all_entra_users(self) -> list[EntraUser]:
@@ -174,7 +174,7 @@ class UnifiedGroupSyncManager:
         """
         if self._all_users_cache is None:
             self._all_users_cache = await self.entra_users.get_users(include_disabled=True)
-            logger.info(f"Loaded {len(self._all_users_cache)} Entra users (including disabled)")
+            logger.info("Loaded %d Entra users (including disabled)", len(self._all_users_cache))
         return self._all_users_cache
 
     async def _add_service_account_to_group(self, group_id: str) -> bool:
@@ -203,7 +203,7 @@ class UnifiedGroupSyncManager:
         )
 
         if not svc_user:
-            logger.warning(f"Could not find {svc_email} to add to group")
+            logger.warning("Could not find %s to add to group", svc_email)
             return False
 
         # Retry logic for adding user (handles provisioning delay)
@@ -222,10 +222,10 @@ class UnifiedGroupSyncManager:
 
         try:
             await _add_with_retry()
-            logger.info(f"Added {svc_email} to group for delegated calendar auth")
+            logger.info("Added %s to group for delegated calendar auth", svc_email)
             return True
         except Exception as e:
-            logger.warning(f"Failed to add {svc_email} to group after retries: {e}")
+            logger.warning("Failed to add %s to group after retries: %s", svc_email, e)
             return False
 
     async def _get_group_members_with_retry(
@@ -261,7 +261,7 @@ class UnifiedGroupSyncManager:
             members = await _get_with_retry()
             return set(members)
         except Exception as e:
-            logger.warning(f"Failed to get group members after retries: {e}")
+            logger.warning("Failed to get group members after retries: %s", e)
             return set()
 
     async def _enforce_m365_group_calendar_settings(
@@ -282,13 +282,13 @@ class UnifiedGroupSyncManager:
         email = f"{mail_nickname}@{self.domain}"
 
         if dry_run:
-            logger.info(f"Would enforce calendar settings for {email}")
+            logger.info("Would enforce calendar settings for %s", email)
             return True
 
         try:
             return await self.exchange_client.set_unified_group_calendar_settings(email)
         except Exception as e:
-            logger.warning(f"Error enforcing calendar settings for {email}: {e}")
+            logger.warning("Error enforcing calendar settings for %s: %s", email, e)
             return False
 
     async def detect_group_type(self, email: str, mail_nickname: str) -> GroupType:
@@ -313,7 +313,7 @@ class UnifiedGroupSyncManager:
         try:
             entra_group = await self.entra_groups.get_group_by_mail_nickname(mail_nickname)
         except Exception as e:
-            logger.debug(f"Error checking Entra for {email}: {e}")
+            logger.debug("Error checking Entra for %s: %s", email, e)
 
         if entra_group:
             # Check if it's an M365 (Unified) group or Exchange mail-enabled security group
@@ -340,7 +340,7 @@ class UnifiedGroupSyncManager:
             if exchange_group:
                 return GroupType.EXCHANGE
         except Exception as e:
-            logger.debug(f"Error checking Exchange for {email}: {e}")
+            logger.debug("Error checking Exchange for %s: %s", email, e)
 
         return GroupType.NONE
 
@@ -379,7 +379,7 @@ class UnifiedGroupSyncManager:
 
         # Handle conflict - exists in both systems
         if detected_type == GroupType.BOTH:
-            logger.warning(f"⚠️  {display_name}: Exists in both M365 and Exchange - SKIPPING")
+            logger.warning("  %s: Exists in both M365 and Exchange - SKIPPING", display_name)
             return GroupSyncResult(
                 group_name=display_name,
                 group_email=email,
@@ -459,7 +459,7 @@ class UnifiedGroupSyncManager:
         newly_created = False
         if creating:
             if dry_run:
-                logger.info(f"Would create M365 group: {display_name}")
+                logger.info("Would create M365 group: %s", display_name)
             else:
                 group = await self.entra_groups.create_m365_group(
                     display_name=display_name,
@@ -467,7 +467,7 @@ class UnifiedGroupSyncManager:
                     description=full_description,
                 )
                 if group:
-                    logger.info(f"Created M365 group: {display_name}")
+                    logger.info("Created M365 group: %s", display_name)
                     newly_created = True
                     # Add service account as member (required for delegated calendar auth)
                     # Uses retry logic to handle provisioning delay
@@ -519,7 +519,7 @@ class UnifiedGroupSyncManager:
                 name = user.display_name or user_id
 
                 if dry_run:
-                    logger.info(f"Would add {name} to {display_name}")
+                    logger.info("Would add %s to %s", name, display_name)
                     added.append(name)
                 else:
                     if await self.entra_groups.add_user_to_group(group.id, user_id):
@@ -541,11 +541,11 @@ class UnifiedGroupSyncManager:
                 if partial_sync and source_emails:
                     user_email = user.email.lower() if user and user.email else None
                     if user_email and user_email not in source_emails:
-                        logger.debug(f"Preserving non-source member: {name}")
+                        logger.debug("Preserving non-source member: %s", name)
                         continue  # Skip removal - not in source data
 
                 if dry_run:
-                    logger.info(f"Would remove {name} from {display_name}")
+                    logger.info("Would remove %s from %s", name, display_name)
                     removed.append(name)
                 else:
                     if await self.entra_groups.remove_user_from_group(group.id, user_id):
@@ -627,7 +627,7 @@ class UnifiedGroupSyncManager:
         # Look up the group's Entra ID
         entra_group = await self.entra_groups.get_group_by_mail_nickname(alias)
         if not entra_group:
-            logger.debug(f"Ghost reconciliation: group {email} not found in Entra ID")
+            logger.debug("Ghost reconciliation: group %s not found in Entra ID", email)
             return removed, errors
 
         # Get all member IDs from Graph API (sees disabled users too)
@@ -661,7 +661,7 @@ class UnifiedGroupSyncManager:
             name = user.display_name or user_email or member_id
 
             if dry_run:
-                logger.info(f"Would remove {name} from {email} (ghost member)")
+                logger.info("Would remove %s from %s (ghost member)", name, email)
                 removed.append(f"{name} (ghost)")
             else:
                 # Use Exchange PowerShell with the directory object ID
@@ -669,7 +669,7 @@ class UnifiedGroupSyncManager:
                 if await self.exchange_client.remove_distribution_group_member(
                     identity=email, member=member_id
                 ):
-                    logger.info(f"Removed ghost member {name} from {email}")
+                    logger.info("Removed ghost member %s from %s", name, email)
                     removed.append(f"{name} (ghost)")
                 else:
                     errors.append(f"Failed to remove ghost member {name} from {email}")
@@ -703,11 +703,11 @@ class UnifiedGroupSyncManager:
         # Handle group creation separately (can't batch with sync)
         if creating:
             if dry_run:
-                logger.info(f"Would create Exchange group: {display_name} ({email})")
+                logger.info("Would create Exchange group: %s (%s)", display_name, email)
                 # For dry-run of new group, all members would be added
                 added = [email_to_member[e].display_name for e in target_emails]
                 for name in added:
-                    logger.info(f"Would add {name} to {email}")
+                    logger.info("Would add %s to %s", name, email)
                 return GroupSyncResult(
                     group_name=display_name,
                     group_email=email,
@@ -732,7 +732,7 @@ class UnifiedGroupSyncManager:
                         group_type=GroupType.EXCHANGE,
                         errors=[f"Failed to create group: {display_name}"],
                     )
-                logger.info(f"Created Exchange group: {display_name} ({email})")
+                logger.info("Created Exchange group: %s (%s)", display_name, email)
 
                 # Set aliases if configured
                 if config.aliases:
@@ -762,12 +762,12 @@ class UnifiedGroupSyncManager:
             for member_email in to_add:
                 member = email_to_member.get(member_email)
                 name = member.display_name if member else member_email
-                logger.info(f"Would add {name} to {email}")
+                logger.info("Would add %s to %s", name, email)
                 added.append(name)
 
             removed = []
             for member_email in to_remove:
-                logger.info(f"Would remove {member_email} from {email}")
+                logger.info("Would remove %s from %s", member_email, email)
                 removed.append(member_email)
 
             # Reconcile ghost members (disabled users invisible to PowerShell)
@@ -813,14 +813,14 @@ class UnifiedGroupSyncManager:
 
         # Log changes
         if result.get("added"):
-            logger.info(f"Updated description for {email}")
-            logger.info(f"Updated ManagedBy for {email}")
+            logger.info("Updated description for %s", email)
+            logger.info("Updated ManagedBy for %s", email)
         for name in added:
-            logger.info(f"Added {name} to {email}")
+            logger.info("Added %s to %s", name, email)
         for member_email in result.get("removed", []):
-            logger.info(f"Removed {member_email} from {email}")
+            logger.info("Removed %s from %s", member_email, email)
         for error in result.get("errors", []):
-            logger.error(f"Error syncing {email}: {error}")
+            logger.error("Error syncing %s: %s", email, error)
 
         # Set aliases if configured (idempotent - won't duplicate existing aliases)
         if config.aliases:
@@ -877,12 +877,14 @@ class UnifiedGroupSyncManager:
         partial_sync = strategy.partial_sync
 
         if not groups_to_sync:
-            logger.warning(f"No groups to sync for strategy: {strategy_name}")
+            logger.warning("No groups to sync for strategy: %s", strategy_name)
             return FullSyncResult()
 
         logger.info(
-            f"Syncing {len(groups_to_sync)} groups for {strategy_name}: "
-            f"{', '.join(sorted(groups_to_sync.keys()))}"
+            "Syncing %d groups for %s: %s",
+            len(groups_to_sync),
+            strategy_name,
+            ", ".join(sorted(groups_to_sync.keys())),
         )
 
         if partial_sync:
@@ -905,7 +907,7 @@ class UnifiedGroupSyncManager:
 
         for group_key in sorted(groups_to_sync.keys()):
             group_members = groups_to_sync[group_key]
-            logger.info(f"Processing {group_key} ({len(group_members)} members)")
+            logger.info("Processing %s (%d members)", group_key, len(group_members))
 
             result = await self.sync_group(
                 strategy=strategy,
@@ -945,30 +947,30 @@ def print_result(result: FullSyncResult, dry_run: bool = False) -> None:
         type_str = type_display.get(group_result.group_type, group_result.group_type.value)
 
         if group_result.skipped:
-            logger.warning(f"\n⚠️  {group_result.group_name} ({group_result.group_email}):")
-            logger.warning(f"  SKIPPED: {group_result.skip_reason}")
+            logger.warning("\n  %s (%s):", group_result.group_name, group_result.group_email)
+            logger.warning("  SKIPPED: %s", group_result.skip_reason)
             continue
 
-        logger.info(f"\n{group_result.group_name} ({group_result.group_email}):")
-        logger.info(f"  Type: {type_str}")
+        logger.info("\n%s (%s):", group_result.group_name, group_result.group_email)
+        logger.info("  Type: %s", type_str)
 
         if group_result.created:
             action = "Would create" if dry_run else "Created"
-            logger.info(f"  Group: {action}")
+            logger.info("  Group: %s", action)
         else:
             logger.info("  Group: Exists")
 
         if group_result.members_added:
             action = "Would add" if dry_run else "Added"
-            logger.info(f"  {action}: {', '.join(group_result.members_added)}")
+            logger.info("  %s: %s", action, ", ".join(group_result.members_added))
 
         if group_result.members_removed:
             action = "Would remove" if dry_run else "Removed"
-            logger.info(f"  {action}: {', '.join(group_result.members_removed)}")
+            logger.info("  %s: %s", action, ", ".join(group_result.members_removed))
 
         if group_result.errors:
             for error in group_result.errors:
-                logger.error(f"  Error: {error}")
+                logger.error("  Error: %s", error)
 
         if not group_result.has_changes and not group_result.errors:
             logger.info("  No changes needed")
@@ -976,14 +978,14 @@ def print_result(result: FullSyncResult, dry_run: bool = False) -> None:
     logger.info("")
     logger.info("-" * 60)
     logger.info("Summary:")
-    logger.info(f"  Groups processed: {len(result.groups)}")
-    logger.info(f"  Groups created: {result.total_created}")
-    logger.info(f"  Members added: {result.total_added}")
-    logger.info(f"  Members removed: {result.total_removed}")
+    logger.info("  Groups processed: %d", len(result.groups))
+    logger.info("  Groups created: %d", result.total_created)
+    logger.info("  Members added: %d", result.total_added)
+    logger.info("  Members removed: %d", result.total_removed)
     if result.total_skipped:
-        logger.warning(f"  Groups skipped (conflicts): {result.total_skipped}")
+        logger.warning("  Groups skipped (conflicts): %d", result.total_skipped)
     if result.total_errors:
-        logger.error(f"  Errors: {result.total_errors}")
+        logger.error("  Errors: %d", result.total_errors)
 
 
 async def backup_groups(
@@ -1031,7 +1033,7 @@ async def backup_groups(
                 config = strategy.get_config(key)
                 mail_nicknames.add(config.mail_nickname)
             except Exception as e:
-                logger.debug(f"Error getting config for {key}: {e}")
+                logger.debug("Error getting config for %s: %s", key, e)
 
     # Fetch existing groups
     for nickname in mail_nicknames:
@@ -1049,9 +1051,9 @@ async def backup_groups(
                         member_ids = await entra_groups.get_group_members(group.id)
                         m365_memberships[group.id] = member_ids
                     except Exception as e:
-                        logger.debug(f"Error getting members for {group.id}: {e}")
+                        logger.debug("Error getting members for %s: %s", group.id, e)
         except Exception as e:
-            logger.debug(f"Error checking M365 group {nickname}: {e}")
+            logger.debug("Error checking M365 group %s: %s", nickname, e)
 
         # Check Exchange (batched: get group + members in one call)
         try:
@@ -1067,22 +1069,22 @@ async def backup_groups(
                     }
                 )
         except Exception as e:
-            logger.debug(f"Error checking Exchange group {email}: {e}")
+            logger.debug("Error checking Exchange group %s: %s", email, e)
 
     # Save backups
     if m365_groups:
         try:
             backup_path = backup_entra_groups(m365_groups, m365_memberships)
-            logger.info(f"M365 groups backup: {backup_path}")
+            logger.info("M365 groups backup: %s", backup_path)
         except Exception as e:
-            logger.error(f"Failed to backup M365 groups: {e}")
+            logger.error("Failed to backup M365 groups: %s", e)
 
     if exchange_groups_data:
         try:
             backup_path = backup_mail_groups(exchange_groups_data)
-            logger.info(f"Exchange groups backup: {backup_path}")
+            logger.info("Exchange groups backup: %s", backup_path)
         except Exception as e:
-            logger.error(f"Failed to backup Exchange groups: {e}")
+            logger.error("Failed to backup Exchange groups: %s", e)
 
     if not m365_groups and not exchange_groups_data:
         logger.info("No existing groups to backup")
@@ -1112,8 +1114,8 @@ async def run_sync(
     if dry_run:
         logger.info("DRY RUN - no changes will be made")
 
-    logger.info(f"Strategies: {', '.join(strategies)}")
-    logger.info(f"New group type: {new_group_type.value}")
+    logger.info("Strategies: %s", ", ".join(strategies))
+    logger.info("New group type: %s", new_group_type.value)
 
     # Initialize manager
     manager = UnifiedGroupSyncManager()
@@ -1129,10 +1131,10 @@ async def run_sync(
             logger.error("No users found in Entra ID")
             return 1
 
-        logger.info(f"Found {len(members)} users")
+        logger.info("Found %d users", len(members))
 
     except Exception as e:
-        logger.error(f"Failed to fetch Entra ID users: {e}")
+        logger.error("Failed to fetch Entra ID users: %s", e)
         return 1
 
     # Backup existing groups before making changes (skip for dry run)
@@ -1144,7 +1146,7 @@ async def run_sync(
                 exchange_client=manager.exchange_client,
             )
         except Exception as e:
-            logger.error(f"Failed to create backup: {e}")
+            logger.error("Failed to create backup: %s", e)
             # Continue with sync even if backup fails
     total_errors = 0
     total_skipped = 0
@@ -1152,7 +1154,7 @@ async def run_sync(
     try:
         for strategy_name in strategies:
             logger.info("")
-            logger.info(f"Running {strategy_name} sync...")
+            logger.info("Running %s sync...", strategy_name)
 
             try:
                 result = await manager.sync(
@@ -1166,7 +1168,7 @@ async def run_sync(
                 total_skipped += result.total_skipped
 
             except Exception as e:
-                logger.error(f"Failed to sync {strategy_name}: {e}")
+                logger.error("Failed to sync %s: %s", strategy_name, e)
                 total_errors += 1
 
     finally:
@@ -1174,8 +1176,9 @@ async def run_sync(
 
     if total_skipped:
         logger.warning(
-            f"\n⚠️  {total_skipped} group(s) skipped due to conflicts. "
-            "These groups exist in both M365 and Exchange and must be resolved manually."
+            "\n  %d group(s) skipped due to conflicts. "
+            "These groups exist in both M365 and Exchange and must be resolved manually.",
+            total_skipped,
         )
 
     return 0 if total_errors == 0 else 1
@@ -1201,11 +1204,11 @@ async def delete_group(email: str, dry_run: bool = False) -> int:
     if dry_run:
         logger.info("DRY RUN - no changes will be made")
 
-    logger.info(f"Target: {email}")
+    logger.info("Target: %s", email)
 
     # Extract mail_nickname from email
     if "@" not in email:
-        logger.error(f"Invalid email format: {email}")
+        logger.error("Invalid email format: %s", email)
         return 1
     mail_nickname = email.split("@")[0]
 
@@ -1216,17 +1219,18 @@ async def delete_group(email: str, dry_run: bool = False) -> int:
         group_type = await manager.detect_group_type(email, mail_nickname)
 
         if group_type == GroupType.NONE:
-            logger.warning(f"Group not found: {email}")
+            logger.warning("Group not found: %s", email)
             return 1
 
         if group_type == GroupType.BOTH:
             logger.error(
-                f"Group exists in both M365 and Exchange: {email}. "
-                "Please delete manually to resolve the conflict."
+                "Group exists in both M365 and Exchange: %s. "
+                "Please delete manually to resolve the conflict.",
+                email,
             )
             return 1
 
-        logger.info(f"Detected group type: {group_type.value.upper()}")
+        logger.info("Detected group type: %s", group_type.value.upper())
 
         # Handle M365 group
         if group_type == GroupType.M365:
@@ -1236,7 +1240,7 @@ async def delete_group(email: str, dry_run: bool = False) -> int:
         return await _delete_exchange_group(manager, email, dry_run)
 
     except Exception as e:
-        logger.error(f"Error: {e}")
+        logger.error("Error: %s", e)
         return 1
     finally:
         await manager.close()
@@ -1262,31 +1266,31 @@ async def _delete_m365_group(
     # Get group details
     group = await manager.entra_groups.get_group_by_mail_nickname(mail_nickname)
     if not group:
-        logger.error(f"M365 group not found: {email}")
+        logger.error("M365 group not found: %s", email)
         return 1
 
-    logger.info(f"Found M365 group: {group.display_name} ({group.mail})")
+    logger.info("Found M365 group: %s (%s)", group.display_name, group.mail)
 
     # Get members for backup
     member_ids = await manager.entra_groups.get_group_members(group.id)
-    logger.info(f"Group has {len(member_ids)} members")
+    logger.info("Group has %d members", len(member_ids))
 
     if dry_run:
-        logger.info(f"Would delete M365 group: {email}")
+        logger.info("Would delete M365 group: %s", email)
         return 0
 
     # Create backup before deleting
     logger.info("Creating backup before delete...")
     memberships = {group.id: member_ids}
     backup_path = backup_entra_groups([group], memberships)
-    logger.info(f"Backup saved: {backup_path}")
+    logger.info("Backup saved: %s", backup_path)
 
     # Delete the group
     if await manager.entra_groups.delete_group(group.id):
-        logger.info(f"Successfully deleted M365 group: {email}")
+        logger.info("Successfully deleted M365 group: %s", email)
         return 0
     else:
-        logger.error(f"Failed to delete M365 group: {email}")
+        logger.error("Failed to delete M365 group: %s", email)
         return 1
 
 
@@ -1309,14 +1313,14 @@ async def _delete_exchange_group(
     group, members = await manager.exchange_client.get_group_with_members(email)
 
     if not group:
-        logger.error(f"Exchange group not found: {email}")
+        logger.error("Exchange group not found: %s", email)
         return 1
 
-    logger.info(f"Found Exchange group: {group.display_name} ({group.primary_smtp_address})")
-    logger.info(f"Group has {len(members)} members")
+    logger.info("Found Exchange group: %s (%s)", group.display_name, group.primary_smtp_address)
+    logger.info("Group has %d members", len(members))
 
     if dry_run:
-        logger.info(f"Would delete Exchange group: {email}")
+        logger.info("Would delete Exchange group: %s", email)
         return 0
 
     # Backup the group before deleting
@@ -1329,14 +1333,14 @@ async def _delete_exchange_group(
         "members": members,
     }
     backup_path = backup_mail_groups([group_data])
-    logger.info(f"Backup saved: {backup_path}")
+    logger.info("Backup saved: %s", backup_path)
 
     # Delete the group
     if await manager.exchange_client.delete_distribution_group(email):
-        logger.info(f"Successfully deleted Exchange group: {email}")
+        logger.info("Successfully deleted Exchange group: %s", email)
         return 0
     else:
-        logger.error(f"Failed to delete Exchange group: {email}")
+        logger.error("Failed to delete Exchange group: %s", email)
         return 1
 
 

--- a/src/sjifire/scripts/personal_calendar_sync.py
+++ b/src/sjifire/scripts/personal_calendar_sync.py
@@ -177,15 +177,15 @@ def main() -> int:
         if args.dry_run:
             logger.info("DRY RUN - no changes will be made")
 
-        logger.info(f"Purging Aladtec events for {args.user}...")
+        logger.info("Purging Aladtec events for %s...", args.user)
         sync = PersonalCalendarSync()
 
         async def do_purge() -> int:
             deleted, errors = await sync.purge_aladtec_events(args.user, args.dry_run)
             if args.dry_run:
-                logger.info(f"Would delete {deleted} events")
+                logger.info("Would delete %d events", deleted)
             else:
-                logger.info(f"Deleted {deleted} events, {errors} errors")
+                logger.info("Deleted %d events, %d errors", deleted, errors)
             return 1 if errors else 0
 
         return asyncio.run(do_purge())
@@ -231,7 +231,7 @@ def main() -> int:
         if not args.user:
             parser.error("--inspect requires --user")
 
-        logger.info(f"Inspecting {args.user} for {start_date} to {end_date}")
+        logger.info("Inspecting %s for %s to %s", args.user, start_date, end_date)
         sync = PersonalCalendarSync()
 
         async def do_inspect() -> int:
@@ -262,7 +262,7 @@ def main() -> int:
 
         return asyncio.run(do_inspect())
 
-    logger.info(f"Syncing {start_date} to {end_date}")
+    logger.info("Syncing %s to %s", start_date, end_date)
 
     # Step 1: Fetch member list from Aladtec to get name->email mapping
     logger.info("Fetching member list from Aladtec...")
@@ -280,20 +280,20 @@ def main() -> int:
                 display_name = f"{member.first_name} {member.last_name}"
                 members[display_name] = member.email
 
-    logger.info(f"Found {len(members)} members with emails")
+    logger.info("Found %d members with emails", len(members))
 
     # Step 2: Get schedule data (from cache or Aladtec)
     if args.load_schedule:
-        logger.info(f"Loading schedule from {args.load_schedule}...")
+        logger.info("Loading schedule from %s...", args.load_schedule)
         try:
             schedules = load_schedules(args.load_schedule)
             # Filter to our date range (cache may have more data)
             schedules = [s for s in schedules if start_date <= s.date <= end_date]
         except FileNotFoundError:
-            logger.error(f"Schedule file not found: {args.load_schedule}")
+            logger.error("Schedule file not found: %s", args.load_schedule)
             return 1
         except Exception as e:
-            logger.error(f"Failed to load schedule: {e}")
+            logger.error("Failed to load schedule: %s", e)
             return 1
     else:
         logger.info("Fetching schedule from Aladtec...")
@@ -303,7 +303,7 @@ def main() -> int:
                 return 1
             schedules = scraper.get_schedule_range(start_date, end_date)
 
-    logger.info(f"Got {len(schedules)} days with schedule data")
+    logger.info("Got %d days with schedule data", len(schedules))
 
     # Step 3: Group entries by user
     entries_by_email: dict[str, list[ScheduleEntry]] = {}
@@ -326,24 +326,24 @@ def main() -> int:
                 unmatched_names.add(entry.name)
 
     if skipped_empty_position:
-        logger.info(f"Skipped {skipped_empty_position} entries with empty position (e.g., Trades)")
+        logger.info("Skipped %d entries with empty position (e.g., Trades)", skipped_empty_position)
 
     if unmatched_names:
-        logger.warning(f"Could not match {len(unmatched_names)} names to emails")
+        logger.warning("Could not match %d names to emails", len(unmatched_names))
         if args.verbose:
             for name in sorted(unmatched_names):
-                logger.debug(f"  Unmatched: {name}")
+                logger.debug("  Unmatched: %s", name)
 
     # Step 4: Filter to requested user(s)
     if args.user:
         user_email = args.user.lower()
         if user_email not in entries_by_email:
-            logger.warning(f"No schedule entries found for {args.user}")
+            logger.warning("No schedule entries found for %s", args.user)
             entries_by_email = {}
         else:
             entries_by_email = {user_email: entries_by_email[user_email]}
 
-    logger.info(f"Syncing calendars for {len(entries_by_email)} users")
+    logger.info("Syncing calendars for %d users", len(entries_by_email))
 
     # Step 5: Sync each user
     sync = PersonalCalendarSync()
@@ -351,12 +351,12 @@ def main() -> int:
     async def sync_all() -> list:
         results = []
         for email, entries in entries_by_email.items():
-            logger.info(f"Syncing {email} ({len(entries)} entries)...")
+            logger.info("Syncing %s (%d entries)...", email, len(entries))
             result = await sync.sync_user(
                 email, entries, start_date, end_date, args.dry_run, args.force
             )
             results.append(result)
-            logger.info(f"  {result}")
+            logger.info("  %s", result)
         return results
 
     results = asyncio.run(sync_all())
@@ -368,11 +368,13 @@ def main() -> int:
     total_errors = sum(len(r.errors) for r in results)
 
     logger.info(
-        f"\nSync complete: {total_created} created, {total_updated} updated, "
-        f"{total_deleted} deleted"
+        "\nSync complete: %d created, %d updated, %d deleted",
+        total_created,
+        total_updated,
+        total_deleted,
     )
     if total_errors:
-        logger.error(f"{total_errors} errors occurred")
+        logger.error("%d errors occurred", total_errors)
         return 1
 
     return 0


### PR DESCRIPTION
## Summary
- Convert 400 f-string logger calls to lazy `%s`/`%d` format across 24 files
- Fix 2 `logger.error(..., exc_info=True)` → `logger.exception()` (G201)
- Add `G` (flake8-logging-format) to ruff lint rules to prevent regression

## Why
F-strings in logger calls are evaluated immediately whether or not the message is emitted. The `%s` style defers interpolation until the log level threshold is met. This is a Python logging best practice and now enforced by ruff.

## Test plan
- [x] `uv run ruff check .` passes (including new G rule)
- [x] `uv run ruff check . --select G` — zero violations
- [x] 2260 tests pass, 7 skipped
- [x] Mechanical change only — no logic changes