### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/calendar-sync.yml
+++ b/.github/workflows/calendar-sync.yml
@@ -41,17 +41,17 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: bb2cb591-58ff-4687-bf14-502049dee01b
           tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd
           allow-no-subscriptions: true
 
       - name: Get secrets from Key Vault
-        uses: azure/cli@v2
+        uses: azure/cli@v3
         with:
           azcliversion: agentazcliversion
           inlineScript: |
@@ -89,7 +89,7 @@ jobs:
             echo "SERVICE_PASSWORD=$SERVICE_PASSWORD" >> $GITHUB_ENV
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 

--- a/.github/workflows/calendar-sync.yml
+++ b/.github/workflows/calendar-sync.yml
@@ -89,7 +89,7 @@ jobs:
             echo "SERVICE_PASSWORD=$SERVICE_PASSWORD" >> $GITHUB_ENV
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -34,10 +34,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -61,10 +61,10 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/entra-sync.yml
+++ b/.github/workflows/entra-sync.yml
@@ -99,7 +99,7 @@ jobs:
           Write-Host "Certificate thumbprint: $($cert.Thumbprint)"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/entra-sync.yml
+++ b/.github/workflows/entra-sync.yml
@@ -41,17 +41,17 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: bb2cb591-58ff-4687-bf14-502049dee01b
           tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd
           allow-no-subscriptions: true
 
       - name: Get secrets from Key Vault
-        uses: azure/cli@v2
+        uses: azure/cli@v3
         with:
           azcliversion: agentazcliversion
           inlineScript: |
@@ -99,7 +99,7 @@ jobs:
           Write-Host "Certificate thumbprint: $($cert.Thumbprint)"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload backup artifacts
         if: ${{ inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: entra-backup-${{ github.run_id }}
           path: backups/

--- a/.github/workflows/ispyfire-sync.yml
+++ b/.github/workflows/ispyfire-sync.yml
@@ -32,17 +32,17 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: bb2cb591-58ff-4687-bf14-502049dee01b
           tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd
           allow-no-subscriptions: true
 
       - name: Get secrets from Key Vault
-        uses: azure/cli@v2
+        uses: azure/cli@v3
         with:
           azcliversion: latest
           inlineScript: |
@@ -71,7 +71,7 @@ jobs:
             echo "ISPYFIRE_PASSWORD=$ISPYFIRE_PASSWORD" >> $GITHUB_ENV
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 
@@ -85,7 +85,7 @@ jobs:
         run: uv run ispyfire-sync --backup --dry-run
 
       - name: Upload backup artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ispyfire-backup-${{ github.run_id }}
           path: backups/

--- a/.github/workflows/ispyfire-sync.yml
+++ b/.github/workflows/ispyfire-sync.yml
@@ -71,7 +71,7 @@ jobs:
             echo "ISPYFIRE_PASSWORD=$ISPYFIRE_PASSWORD" >> $GITHUB_ENV
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/ops-deploy.yml
+++ b/.github/workflows/ops-deploy.yml
@@ -26,10 +26,10 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Azure login with OIDC
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: bb2cb591-58ff-4687-bf14-502049dee01b
           tenant-id: 4122848f-c317-4267-9c07-7c504150d1bd


### PR DESCRIPTION
## Summary

- Update all GitHub Actions to latest major versions that support Node.js 24
- Resolves deprecation warnings: Node.js 20 actions will be forced to Node.js 24 starting June 2, 2026

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v6 |
| `astral-sh/setup-uv` | v5 | v8 |
| `azure/login` | v2 | v3 |
| `azure/cli` | v2 | v3 |
| `actions/upload-artifact` | v4 | v7 |

## Test plan

- [ ] CI passes on this PR (validates checkout, uv, lint, test, e2e all work with new versions)