### PR TITLE
Strip PII from dispatch logs before they reach reports

### DIFF
--- a/docs/dispatch-cheatsheet.md
+++ b/docs/dispatch-cheatsheet.md
@@ -14,20 +14,25 @@ Given a dispatch call's radio log and CAD comments, extract the following as JSO
   "patient_count": 0,
   "escalated": false,
   "outcome": "Brief outcome: 'transported', 'fire controlled', 'false alarm', 'cancelled', 'no patient', etc.",
-  "key_events": ["Chronological list of significant events from the radio log — scene conditions, size-up reports, command establishment/transfers, patient info, key decisions, hazards, cancellations, staging locations. Exclude routine status changes (enroute, on scene, cleared) since those are captured separately — but ALWAYS include ARSTN/staging events with the staging location. One event per entry, include the unit and time."]
+  "key_events": ["Chronological list of significant events from the radio log — scene conditions, size-up reports, command establishment/transfers, patient info, key decisions, hazards, cancellations, staging locations. Exclude routine status changes (enroute, on scene, cleared) since those are captured separately — but ALWAYS include ARSTN/staging events with the staging location. One event per entry, include the unit and time."],
+  "sanitized_cad_comments": "Full CAD comments blob, rewritten VERBATIM except for PII. Preserve the original format — timestamp headers like '18:56:01 02/02/2026 - M Rennick' on their own line, followed by narrative lines. Preserve all operational content word-for-word: unit codes, addresses, actions, conditions, cross streets, dispatcher names, action/disposition codes. REWRITE only: patient/civilian age + gender (→ 'the patient'), patient/civilian names (→ 'the patient' / 'the occupant'), caller/RP names (→ 'the caller'), phone numbers (→ '[phone]'). Do NOT add or remove lines. Do NOT summarize. If the original is empty, return empty string.",
+  "sanitized_radio_notes": [{"timestamp": "matches time_of_status_change verbatim", "unit": "matches unit_number verbatim", "text": "sanitized radio_log text — same rules as sanitized_cad_comments"}]
 }
 ```
 
 Rules:
 - Return ONLY valid JSON. No markdown, no explanation, no code fences.
 - Include ALL fields shown in the schema above. Every field is required in the response.
+- **NO PII**: Do NOT include patient/civilian age, gender, or names in summary, short_dsc, key_events, sanitized_cad_comments, or sanitized_radio_notes. Use "patient", "caller", "occupant" instead of "72-year-old male" or "13yo female". Example: write "patient fall, transported" not "72yo male fall". The address is fine. Dispatcher names (e.g. "M Rennick" in timestamp headers) are fine — only patient/caller names are PII.
+- **sanitized_cad_comments** must include ONE entry for every line in the original cad_comments blob, in the same order. It is NOT a summary — it is a verbatim copy with PII stripped. Example: "13yo female passenger, possible head injury" → "the patient, possible head injury". Example: "caller: John Smith advises" → "the caller advises". Example: "callback (360) 378-4141" → "callback [phone]".
+- **sanitized_radio_notes** must include ONE entry for every NOTE-status item in responder_details, with timestamp + unit copied verbatim and text sanitized. Skip non-NOTE entries. If there are no NOTE entries, return an empty array.
 - Use unit codes as they appear in the radio log (e.g. BN31, E31, M31).
 - For incident_commander, only include units that explicitly took or were given command.
 - For incident_commander_name, match the IC unit code to the on-duty crew list (if provided) to find the person's name. If command transferred (e.g. "BN31 → L31"), use the most senior officer in the chain — typically the chief officer over a company officer.
 - patient_count should be 0 for non-medical calls.
 - escalated is true if mutual aid was requested, additional alarms struck, significant resource escalation occurred, or additional units/agencies were paged after the initial dispatch (e.g., requesting a second ambulance, all-agency repage).
 - Keep summary factual and concise — no speculation.
-- key_events should capture everything an incident reporter would need: conditions on arrival, command posts, patient details, fire behavior, hazards, mutual aid requests, cancellations, and staging locations. Format each entry as "HH:MM Unit — what happened" (e.g., "17:00 BN31 — nothing showing, investigating, est Farm Rd Command"). Exclude routine status changes (paged, enroute, on scene, cleared, RTQ) since those are in unit_times — but ALWAYS include ARSTN/staging events because staging is NOT the same as arriving on scene (e.g., "17:15 T33 — staging on Cattle Point Rd").
+- key_events should capture everything an incident reporter would need: conditions on arrival, command posts, care provided, fire behavior, hazards, mutual aid requests, cancellations, and staging locations. Format each entry as "HH:MM Unit — what happened" (e.g., "17:00 BN31 — nothing showing, investigating, est Farm Rd Command"). Exclude routine status changes (paged, enroute, on scene, cleared, RTQ) since those are in unit_times — but ALWAYS include ARSTN/staging events because staging is NOT the same as arriving on scene (e.g., "17:15 T33 — staging on Cattle Point Rd").
 
 ---
 

--- a/docs/neris/incident-report-instructions.md
+++ b/docs/neris/incident-report-instructions.md
@@ -635,9 +635,11 @@ For fatal casualties, flag that additional documentation and investigation may b
 
 Now that you have incident type, units/crew, actions, location, and any conditional module details (fire, medical, rescue, hazmat), draft the outcome narrative incorporating everything:
 
+**PII RULE — NO patient demographics in the narrative.** Do NOT include age, gender, or names of patients/civilians. Use "the patient", "the caller", "the occupant", etc. instead of "72-year-old male" or "13yo female". This applies to ALL narratives — medical, fire, rescue, hazmat. Dispatch logs are automatically redacted before you see them, but if any slip through or the user provides demographics verbally, still omit them from the written narrative. The address is fine to include.
+
 > Based on what you've told me, here's a draft narrative:
 >
-> *"Engine 31 and Medic 31 responded to 200 Spring St for a reported fall. On arrival, found a 72-year-old male who had fallen from a standing position. Patient was conscious and alert with complaint of left hip pain. BLS care was provided and patient was transported to PeaceHealth by M31. Scene cleared at 15:22."*
+> *"Engine 31 and Medic 31 responded to 200 Spring St for a reported fall. On arrival, the patient had fallen from a standing position. Patient was conscious and alert with complaint of left hip pain. BLS care was provided and the patient was transported to PeaceHealth by M31. Scene cleared at 15:22."*
 >
 > Want me to adjust anything?
 
@@ -660,7 +662,7 @@ Summarize everything and highlight any gaps:
 > **Units**: E31, M31 (4 personnel)
 > **Times**: Dispatch 14:30 → On scene 14:38 → Clear 15:22
 > **Actions**: Patient assessment, Provide BLS, Provide transport
-> **Narrative**: "Engine 31 and Medic 31 responded to 200 Spring St for a reported fall. On arrival, found a 72-year-old male who had fallen from a standing position. Patient was conscious and alert with complaint of left hip pain. BLS care was provided and patient was transported to PeaceHealth by M31. Scene cleared at 15:22."
+> **Narrative**: "Engine 31 and Medic 31 responded to 200 Spring St for a reported fall. On arrival, the patient had fallen from a standing position. Patient was conscious and alert with complaint of left hip pain. BLS care was provided and the patient was transported to PeaceHealth by M31. Scene cleared at 15:22."
 >
 > ✅ All required fields complete
 > ⚠️ Missing: Cross streets (optional)
@@ -830,5 +832,6 @@ update_incident(extras={
 - See the DEPARTMENT-SPECIFIC section for station, city, nicknames, shifts, and mutual aid details
 - If the user seems unsure about a NERIS classification, offer to look up values: "Want me to show you all the options for [field]?"
 - Keep narratives factual, professional, and concise — avoid subjective language
+- **No PII in narratives or logs** — never include patient/civilian age, gender, or names. Use generic terms: "the patient", "the caller", "the occupant"
 - Don't over-ask — if dispatch data answers a question, just confirm rather than re-asking
 - **Always show before saving** — When the user corrects, adjusts, or rewrites any content (narrative, actions, crew, etc.), show the revised version and ask for confirmation before calling `update_incident`. Never silently save corrections — the user needs to verify the change is right.

--- a/src/sjifire/core/pii.py
+++ b/src/sjifire/core/pii.py
@@ -39,9 +39,15 @@ _AGE_RE = re.compile(
 _PHONE_RE = re.compile(r"\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}")
 
 # Caller/reporting party names: "caller: John Smith", "RP Jane Doe"
+#
+# The keyword (caller / RP / reporting party) is matched case-insensitively
+# via a scoped flag.  The name capture stays case-sensitive — otherwise the
+# whole pattern over-matches operational narrative like "the caller was mad"
+# or "after the caller hung up" (any two lowercase words after the keyword
+# would be treated as a name).  All-caps names like "CALLER: JOHN SMITH"
+# are a known limitation of the stricter name pattern; the LLM catches those.
 _CALLER_RE = re.compile(
-    rf"(?:caller|rp|reporting\s+party)\s*[:{_DASH}]?\s*[A-Z][a-z]+\s+[A-Z][a-z]+",
-    re.IGNORECASE,
+    rf"(?i:caller|rp|reporting\s+party)\s*[:{_DASH}]?\s*[A-Z][a-z]+\s+[A-Z][a-z]+",
 )
 
 

--- a/src/sjifire/core/pii.py
+++ b/src/sjifire/core/pii.py
@@ -6,7 +6,17 @@ dispatch data in Cosmos DB is kept intact; redaction is applied when data
 surfaces to reports, narratives, or the AI chat context.
 """
 
+import logging
 import re
+
+logger = logging.getLogger(__name__)
+
+# Sanity cap on the input size redact_pii will process.  Dispatch CAD
+# comments are typically <10KB; the IncidentDocument schema caps
+# dispatch_comments at 100KB.  Anything above this is either malformed
+# upstream data or a crafted adversarial input — log a warning so we
+# notice, but still process (the regexes are linear-time in practice).
+_MAX_INPUT_BYTES = 200_000
 
 # Hyphen-like separators: regular hyphen + en-dash (U+2013)
 _DASH = "-\u2013"
@@ -53,6 +63,16 @@ def redact_pii(text: str) -> str:
     """
     if not text:
         return text
+
+    if len(text) > _MAX_INPUT_BYTES:
+        # Canary: something upstream produced an unexpectedly large blob.
+        # The regexes are linear-time in practice so we still process it,
+        # but we want to notice if it becomes common.
+        logger.warning(
+            "redact_pii received oversized input: %d chars (cap: %d)",
+            len(text),
+            _MAX_INPUT_BYTES,
+        )
 
     # Order matters: age+gender first (more specific), then standalone age
     text = _AGE_GENDER_RE.sub("[patient]", text)

--- a/src/sjifire/core/pii.py
+++ b/src/sjifire/core/pii.py
@@ -60,36 +60,3 @@ def redact_pii(text: str) -> str:
     text = _PHONE_RE.sub("[phone]", text)
     text = _CALLER_RE.sub("[caller]", text)
     return text
-
-
-def redact_dispatch_dict(d: dict) -> dict:
-    """Redact PII from a dispatch call dict (output of ``to_dict()``).
-
-    Modifies the dict **in place** and returns it.  Redacts:
-
-    - ``cad_comments`` (raw CAD blob)
-    - ``responder_details[].radio_log`` (individual radio log entries)
-    - ``analysis.summary``, ``analysis.key_events``, ``analysis.short_dsc``
-
-    Args:
-        d: Dispatch call dict from ``DispatchCallDocument.to_dict()``
-
-    Returns:
-        The same dict with PII fields redacted.
-    """
-    if d.get("cad_comments"):
-        d["cad_comments"] = redact_pii(d["cad_comments"])
-
-    for entry in d.get("responder_details", []):
-        if entry.get("radio_log"):
-            entry["radio_log"] = redact_pii(entry["radio_log"])
-
-    analysis = d.get("analysis")
-    if isinstance(analysis, dict):
-        if analysis.get("summary"):
-            analysis["summary"] = redact_pii(analysis["summary"])
-        if analysis.get("short_dsc"):
-            analysis["short_dsc"] = redact_pii(analysis["short_dsc"])
-        analysis["key_events"] = [redact_pii(e) for e in analysis.get("key_events", [])]
-
-    return d

--- a/src/sjifire/core/pii.py
+++ b/src/sjifire/core/pii.py
@@ -1,0 +1,95 @@
+"""PII redaction for dispatch logs and incident data.
+
+Strips personally identifiable information (patient demographics, phone
+numbers) from dispatch text while preserving operational content.  The raw
+dispatch data in Cosmos DB is kept intact; redaction is applied when data
+surfaces to reports, narratives, or the AI chat context.
+"""
+
+import re
+
+# Hyphen-like separators: regular hyphen + en-dash (U+2013)
+_DASH = "-\u2013"
+
+# Age + gender: "13yo female", "72-year-old male", "9 yr old boy", "55 y/o m"
+_AGE_GENDER_RE = re.compile(
+    rf"\b\d{{1,3}}\s*[{_DASH}]?\s*"
+    rf"(?:y/?\.?o\.?|year[{_DASH}\s]*old|yr[{_DASH}\s]*old)"
+    r"\s+(?:male|female|man|woman|boy|girl|m\b|f\b)",
+    re.IGNORECASE,
+)
+
+# Standalone age descriptor: "13yo", "72 year old" (no gender follows)
+_AGE_RE = re.compile(
+    rf"\b\d{{1,3}}\s*[{_DASH}]?\s*(?:y/?\.?o\.?|year[{_DASH}\s]*old|yr[{_DASH}\s]*old)\b",
+    re.IGNORECASE,
+)
+
+# Phone numbers: (360) 555-1234, 360-555-1234, 360.555.1234
+_PHONE_RE = re.compile(r"\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}")
+
+# Caller/reporting party names: "caller: John Smith", "RP Jane Doe"
+_CALLER_RE = re.compile(
+    rf"(?:caller|rp|reporting\s+party)\s*[:{_DASH}]?\s*[A-Z][a-z]+\s+[A-Z][a-z]+",
+    re.IGNORECASE,
+)
+
+
+def redact_pii(text: str) -> str:
+    """Remove patient demographics and phone numbers from text.
+
+    Replaces age+gender descriptors (e.g. "13yo female") and standalone
+    age descriptors (e.g. "72yo") with ``[patient]``, phone numbers with
+    ``[phone]``, and caller/RP names with ``[caller]``.
+
+    Operational content (addresses, unit codes, actions, conditions) is
+    preserved.
+
+    Args:
+        text: Raw dispatch text (CAD comments, radio log notes, etc.)
+
+    Returns:
+        Text with PII patterns replaced by bracketed placeholders.
+    """
+    if not text:
+        return text
+
+    # Order matters: age+gender first (more specific), then standalone age
+    text = _AGE_GENDER_RE.sub("[patient]", text)
+    text = _AGE_RE.sub("[patient]", text)
+    text = _PHONE_RE.sub("[phone]", text)
+    text = _CALLER_RE.sub("[caller]", text)
+    return text
+
+
+def redact_dispatch_dict(d: dict) -> dict:
+    """Redact PII from a dispatch call dict (output of ``to_dict()``).
+
+    Modifies the dict **in place** and returns it.  Redacts:
+
+    - ``cad_comments`` (raw CAD blob)
+    - ``responder_details[].radio_log`` (individual radio log entries)
+    - ``analysis.summary``, ``analysis.key_events``, ``analysis.short_dsc``
+
+    Args:
+        d: Dispatch call dict from ``DispatchCallDocument.to_dict()``
+
+    Returns:
+        The same dict with PII fields redacted.
+    """
+    if d.get("cad_comments"):
+        d["cad_comments"] = redact_pii(d["cad_comments"])
+
+    for entry in d.get("responder_details", []):
+        if entry.get("radio_log"):
+            entry["radio_log"] = redact_pii(entry["radio_log"])
+
+    analysis = d.get("analysis")
+    if isinstance(analysis, dict):
+        if analysis.get("summary"):
+            analysis["summary"] = redact_pii(analysis["summary"])
+        if analysis.get("short_dsc"):
+            analysis["short_dsc"] = redact_pii(analysis["short_dsc"])
+        analysis["key_events"] = [redact_pii(e) for e in analysis.get("key_events", [])]
+
+    return d

--- a/src/sjifire/ops/chat/engine.py
+++ b/src/sjifire/ops/chat/engine.py
@@ -18,6 +18,7 @@ from anthropic import AsyncAnthropic, RateLimitError
 
 from sjifire.core.anthropic import MODEL, cached_system, get_client
 from sjifire.core.config import get_org_config, local_now
+from sjifire.core.pii import redact_pii
 from sjifire.ops.auth import UserContext
 from sjifire.ops.chat.budget import check_budget, record_usage
 from sjifire.ops.chat.centrifugo import publish
@@ -35,6 +36,7 @@ from sjifire.ops.chat.tools import (
     execute_tool,
 )
 from sjifire.ops.chat.turn_lock import TurnLockStore
+from sjifire.ops.dispatch.sanitize import sanitize_cad_comments
 
 # Set of fire-and-forget tasks — prevents GC from collecting running tasks.
 _background_tasks: set[asyncio.Task] = set()
@@ -551,7 +553,7 @@ async def _fetch_context(
                         "address": dispatch.address,
                         "time_reported": dispatch.time_reported,
                         "geo_location": dispatch.geo_location,
-                        "cad_comments": dispatch.cad_comments,
+                        "cad_comments": sanitize_cad_comments(dispatch),
                     }
                     if dispatch.analysis:
                         analysis = dispatch.analysis
@@ -560,6 +562,14 @@ async def _fetch_context(
                         analysis_dict = analysis.model_dump(mode="json")
                         unit_times = analysis_dict.pop("unit_times", [])
                         analysis_dict.pop("on_duty_crew", None)
+                        # Redact PII from AI-generated text fields
+                        if analysis_dict.get("summary"):
+                            analysis_dict["summary"] = redact_pii(analysis_dict["summary"])
+                        if analysis_dict.get("short_dsc"):
+                            analysis_dict["short_dsc"] = redact_pii(analysis_dict["short_dsc"])
+                        analysis_dict["key_events"] = [
+                            redact_pii(e) for e in analysis_dict.get("key_events", [])
+                        ]
                         slim["analysis"] = analysis_dict
                         # Format unit_times as a readable table for easy review
                         if unit_times:

--- a/src/sjifire/ops/dispatch/enrich.py
+++ b/src/sjifire/ops/dispatch/enrich.py
@@ -57,7 +57,10 @@ async def enrich_dispatch(doc: DispatchCallDocument) -> DispatchAnalysis:
     # blindly trust it.  Run redact_pii over every PII-bearing field so
     # any slippage gets caught at ingestion rather than leaking to
     # reports or NERIS downstream.  Idempotent — clean text is unchanged.
-    _scrub_llm_output(analysis)
+    # Emits a structured log whenever the safety net actually changes
+    # something — see issue #93 for how we use this to measure LLM leak
+    # rate in production.
+    _scrub_llm_output(analysis, dispatch_id=doc.long_term_call_id)
 
     # Attach the crew roster
     analysis.on_duty_crew = crew
@@ -80,7 +83,7 @@ async def enrich_dispatch(doc: DispatchCallDocument) -> DispatchAnalysis:
 # ---------------------------------------------------------------------------
 
 
-def _scrub_llm_output(analysis: DispatchAnalysis) -> None:
+def _scrub_llm_output(analysis: DispatchAnalysis, *, dispatch_id: str = "") -> None:
     """Run regex PII redaction over every LLM-written field in-place.
 
     Defense in depth: the enrichment prompt tells the LLM to keep its
@@ -90,25 +93,67 @@ def _scrub_llm_output(analysis: DispatchAnalysis) -> None:
     verbatim, so downstream consumers (chat engine, MCP tools,
     incident documents, NERIS) never see it.
 
+    Emits a structured WARNING log whenever regex actually changes
+    something — that's a signal the LLM leaked PII.  The log contains
+    only the dispatch id and the list of field names that changed —
+    never the raw text, since by definition it contained PII.  This
+    instrumentation is what feeds the leak-rate measurement in
+    issue #93.
+
     Idempotent — already-clean text is unchanged.  Only touches
     LLM-authored fields; deterministic fields (``unit_times``,
     ``on_duty_crew``, ``incident_commander_name``, ``alarm_time``,
     etc.) are left alone.
+
+    Args:
+        analysis: The DispatchAnalysis to scrub in place.
+        dispatch_id: Human-readable dispatch identifier (e.g. "26-001678")
+            for correlation in logs.  Optional but strongly recommended.
     """
-    analysis.summary = redact_pii(analysis.summary)
-    analysis.short_dsc = redact_pii(analysis.short_dsc)
-    analysis.outcome = redact_pii(analysis.outcome)
-    analysis.actions_taken = [redact_pii(a) for a in analysis.actions_taken]
-    analysis.key_events = [redact_pii(e) for e in analysis.key_events]
-    analysis.sanitized_cad_comments = redact_pii(analysis.sanitized_cad_comments)
-    analysis.sanitized_radio_notes = [
-        SanitizedNote(
-            timestamp=n.timestamp,
-            unit=n.unit,
-            text=redact_pii(n.text),
-        )
+    changed_fields: list[str] = []
+
+    def _scrub(field: str, value: str) -> str:
+        cleaned = redact_pii(value)
+        if cleaned != value:
+            changed_fields.append(field)
+        return cleaned
+
+    analysis.summary = _scrub("summary", analysis.summary)
+    analysis.short_dsc = _scrub("short_dsc", analysis.short_dsc)
+    analysis.outcome = _scrub("outcome", analysis.outcome)
+
+    cleaned_actions = [redact_pii(a) for a in analysis.actions_taken]
+    if cleaned_actions != analysis.actions_taken:
+        changed_fields.append("actions_taken")
+    analysis.actions_taken = cleaned_actions
+
+    cleaned_events = [redact_pii(e) for e in analysis.key_events]
+    if cleaned_events != analysis.key_events:
+        changed_fields.append("key_events")
+    analysis.key_events = cleaned_events
+
+    analysis.sanitized_cad_comments = _scrub(
+        "sanitized_cad_comments", analysis.sanitized_cad_comments
+    )
+
+    cleaned_notes = [
+        SanitizedNote(timestamp=n.timestamp, unit=n.unit, text=redact_pii(n.text))
         for n in analysis.sanitized_radio_notes
     ]
+    if any(
+        c.text != o.text for c, o in zip(cleaned_notes, analysis.sanitized_radio_notes, strict=True)
+    ):
+        changed_fields.append("sanitized_radio_notes")
+    analysis.sanitized_radio_notes = cleaned_notes
+
+    if changed_fields:
+        # Safe to include: dispatch_id and field names are not PII.
+        # NEVER log the before/after text — it contained PII by definition.
+        logger.warning(
+            "pii_safety_net_triggered: dispatch_id=%s fields=%s",
+            dispatch_id or "(unknown)",
+            changed_fields,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/sjifire/ops/dispatch/enrich.py
+++ b/src/sjifire/ops/dispatch/enrich.py
@@ -12,11 +12,13 @@ import re
 from datetime import timedelta
 
 from sjifire.core.config import get_org_config
+from sjifire.core.pii import redact_pii
 from sjifire.core.schedule import position_sort_key
 from sjifire.ops.dispatch.models import (
     CrewOnDuty,
     DispatchAnalysis,
     DispatchCallDocument,
+    SanitizedNote,
     UnitTiming,
 )
 from sjifire.ops.schedule.models import ScheduleEntryCache
@@ -49,6 +51,14 @@ async def enrich_dispatch(doc: DispatchCallDocument) -> DispatchAnalysis:
     # LLM analysis with crew roster included in the prompt
     analysis = await analyze_dispatch(doc, crew_context)
 
+    # Defense in depth: regex safety net over LLM output.  The cheatsheet
+    # prompt instructs the LLM to strip patient/civilian demographics,
+    # names, and phone numbers from its sanitized_* fields, but we don't
+    # blindly trust it.  Run redact_pii over every PII-bearing field so
+    # any slippage gets caught at ingestion rather than leaking to
+    # reports or NERIS downstream.  Idempotent — clean text is unchanged.
+    _scrub_llm_output(analysis)
+
     # Attach the crew roster
     analysis.on_duty_crew = crew
 
@@ -63,6 +73,42 @@ async def enrich_dispatch(doc: DispatchCallDocument) -> DispatchAnalysis:
     _extract_unit_times(doc, analysis)
 
     return analysis
+
+
+# ---------------------------------------------------------------------------
+# PII safety net
+# ---------------------------------------------------------------------------
+
+
+def _scrub_llm_output(analysis: DispatchAnalysis) -> None:
+    """Run regex PII redaction over every LLM-written field in-place.
+
+    Defense in depth: the enrichment prompt tells the LLM to keep its
+    sanitized_* output free of patient/civilian demographics, names,
+    and phone numbers, but we don't rely on that alone.  This pass
+    catches any obvious PII the LLM missed, skipped, or echoed back
+    verbatim, so downstream consumers (chat engine, MCP tools,
+    incident documents, NERIS) never see it.
+
+    Idempotent — already-clean text is unchanged.  Only touches
+    LLM-authored fields; deterministic fields (``unit_times``,
+    ``on_duty_crew``, ``incident_commander_name``, ``alarm_time``,
+    etc.) are left alone.
+    """
+    analysis.summary = redact_pii(analysis.summary)
+    analysis.short_dsc = redact_pii(analysis.short_dsc)
+    analysis.outcome = redact_pii(analysis.outcome)
+    analysis.actions_taken = [redact_pii(a) for a in analysis.actions_taken]
+    analysis.key_events = [redact_pii(e) for e in analysis.key_events]
+    analysis.sanitized_cad_comments = redact_pii(analysis.sanitized_cad_comments)
+    analysis.sanitized_radio_notes = [
+        SanitizedNote(
+            timestamp=n.timestamp,
+            unit=n.unit,
+            text=redact_pii(n.text),
+        )
+        for n in analysis.sanitized_radio_notes
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/sjifire/ops/dispatch/models.py
+++ b/src/sjifire/ops/dispatch/models.py
@@ -46,6 +46,25 @@ class UnitTiming(BaseModel):
     """ISO timestamp when this unit returned to quarters (RTQ status)."""
 
 
+class SanitizedNote(BaseModel):
+    """A radio log NOTE entry with PII removed by the enrichment LLM.
+
+    Mirrors the ``(timestamp, unit, radio_log)`` shape of iSpyFire NOTE
+    entries in ``responder_details``, with ``text`` rewritten to strip
+    patient/civilian demographics, names, and phone numbers while
+    preserving operational content.
+    """
+
+    timestamp: str = ""
+    """ISO 8601 timestamp matching the source ``time_of_status_change``."""
+
+    unit: str = ""
+    """Unit code matching the source ``unit_number``."""
+
+    text: str = ""
+    """Sanitized radio log text (PII removed)."""
+
+
 class DispatchAnalysis(BaseModel):
     """AI-extracted structured analysis of a dispatch call.
 
@@ -97,6 +116,29 @@ class DispatchAnalysis(BaseModel):
     conditions, command changes, patient info, key decisions — everything
     the incident reporter needs. Status changes (enroute, on scene, etc.)
     are excluded since they're already in ``unit_times``.
+    """
+
+    sanitized_cad_comments: str = ""
+    """Full CAD comments blob with PII removed by the enrichment LLM.
+
+    Preserves the original format (timestamp headers + narrative lines)
+    but rewrites patient/civilian demographics, names, and phone numbers
+    as ``the patient``, ``the caller``, etc. Operational content (unit
+    codes, addresses, actions, conditions, dispatcher names) is preserved
+    verbatim. Used as the LLM-facing / report-facing version of
+    ``cad_comments``; the raw blob is retained for human UI display.
+
+    Empty string for un-enriched records — callers should fall back to
+    regex-based redaction of ``cad_comments`` when this is empty.
+    """
+
+    sanitized_radio_notes: list[SanitizedNote] = []
+    """NOTE entries from ``responder_details`` with PII removed.
+
+    One entry per NOTE-status item in the original ``responder_details``,
+    keyed by ``(timestamp, unit)`` so callers can match them back to raw
+    entries. Empty list for un-enriched records — fall back to regex
+    redaction of the raw ``radio_log`` text.
     """
 
 

--- a/src/sjifire/ops/dispatch/sanitize.py
+++ b/src/sjifire/ops/dispatch/sanitize.py
@@ -1,0 +1,138 @@
+"""LLM-facing sanitization helpers for dispatch call data.
+
+Prefers ``DispatchAnalysis.sanitized_cad_comments`` and
+``sanitized_radio_notes`` (produced by the enrichment LLM) and falls
+back to regex-based redaction from ``sjifire.core.pii`` for records
+that haven't been enriched yet.
+
+**Policy:** raw dispatch data (``cad_comments``, ``responder_details``)
+is kept untouched in Cosmos DB and surfaced to human-facing UIs
+(dashboard, kiosk, chat sidebar).  These helpers produce the version
+shown to Claude — via MCP tools, the chat engine system prompt, and
+incident documents (which ultimately flow to NERIS).
+"""
+
+import html
+
+from sjifire.core.pii import redact_pii
+from sjifire.ops.dispatch.models import DispatchCallDocument
+
+
+def sanitize_cad_comments(doc: DispatchCallDocument) -> str:
+    """Return the LLM-facing CAD comments for a dispatch call.
+
+    Prefers ``doc.analysis.sanitized_cad_comments`` (written by the
+    enrichment LLM per the instructions in ``docs/dispatch-cheatsheet.md``).
+    Falls back to regex-based redaction of the raw ``cad_comments``
+    blob for un-enriched records.
+
+    Always HTML-decodes the source (iSpyFire encodes apostrophes, etc.)
+    before returning.
+    """
+    if doc.analysis and doc.analysis.sanitized_cad_comments:
+        return html.unescape(doc.analysis.sanitized_cad_comments)
+    if not doc.cad_comments:
+        return ""
+    return redact_pii(html.unescape(doc.cad_comments))
+
+
+def sanitize_radio_notes(doc: DispatchCallDocument) -> list[dict]:
+    """Return LLM-facing NOTE entries from a dispatch call's radio log.
+
+    Each dict has ``timestamp``, ``unit``, and ``text`` keys — matching
+    the shape that ``_extract_dispatch_notes`` produces from raw
+    ``responder_details``.
+
+    Prefers ``doc.analysis.sanitized_radio_notes`` when populated.
+    Falls back to regex-redacting the raw NOTE entries from
+    ``responder_details`` for un-enriched records.
+    """
+    if doc.analysis and doc.analysis.sanitized_radio_notes:
+        return [
+            {
+                "timestamp": n.timestamp,
+                "unit": n.unit,
+                "text": html.unescape(n.text),
+            }
+            for n in doc.analysis.sanitized_radio_notes
+            if n.text
+        ]
+
+    notes: list[dict] = []
+    for entry in doc.responder_details or []:
+        if entry.get("status") != "NOTE":
+            continue
+        text = html.unescape(entry.get("radio_log", "") or "").strip()
+        if not text:
+            continue
+        notes.append(
+            {
+                "timestamp": str(entry.get("time_of_status_change", "")),
+                "unit": entry.get("unit_number", ""),
+                "text": redact_pii(text),
+            }
+        )
+    return notes
+
+
+def sanitize_dispatch_for_llm(doc: DispatchCallDocument) -> dict:
+    """Return a dispatch call dict suitable for LLM consumption.
+
+    Starts from ``doc.to_dict()`` and replaces PII-bearing fields with
+    their sanitized equivalents:
+
+    - ``cad_comments`` → from ``sanitize_cad_comments(doc)``
+    - ``responder_details[].radio_log`` for NOTE entries → matched from
+      ``doc.analysis.sanitized_radio_notes`` by ``(timestamp, unit)``,
+      falling back to regex redaction for unmatched entries
+    - ``analysis.summary`` / ``short_dsc`` / ``key_events`` → regex-
+      redacted as a safety net (the enrichment prompt already tells the
+      LLM to keep these PII-free)
+
+    Does not mutate ``doc``. Returns a fresh dict safe for the caller
+    to further modify.
+
+    Use this in MCP dispatch tools (``get_dispatch_call``, etc.) and
+    anywhere else Claude receives a full dispatch dict.
+    """
+    d = doc.to_dict()
+
+    # cad_comments: prefer LLM sanitized version
+    if doc.cad_comments or (doc.analysis and doc.analysis.sanitized_cad_comments):
+        d["cad_comments"] = sanitize_cad_comments(doc)
+
+    # responder_details: sanitize NOTE radio_log entries
+    sanitized_lookup: dict[tuple[str, str], str] = {}
+    if doc.analysis and doc.analysis.sanitized_radio_notes:
+        sanitized_lookup = {
+            (n.timestamp, n.unit): n.text for n in doc.analysis.sanitized_radio_notes if n.text
+        }
+
+    for entry in d.get("responder_details", []):
+        if entry.get("status") != "NOTE":
+            continue
+        raw_text = entry.get("radio_log") or ""
+        if not raw_text:
+            continue
+        key = (
+            str(entry.get("time_of_status_change", "")),
+            entry.get("unit_number", ""),
+        )
+        if key in sanitized_lookup:
+            entry["radio_log"] = sanitized_lookup[key]
+        else:
+            entry["radio_log"] = redact_pii(raw_text)
+
+    # analysis: safety-net regex pass over text fields
+    analysis = d.get("analysis")
+    if isinstance(analysis, dict):
+        if analysis.get("summary"):
+            analysis["summary"] = redact_pii(analysis["summary"])
+        if analysis.get("short_dsc"):
+            analysis["short_dsc"] = redact_pii(analysis["short_dsc"])
+        analysis["key_events"] = [redact_pii(e) for e in analysis.get("key_events", [])]
+        # Raw sanitized fields are already clean by construction; no need to
+        # re-process them. They're kept in the dict so callers that want
+        # them explicitly can still access them.
+
+    return d

--- a/src/sjifire/ops/dispatch/sanitize.py
+++ b/src/sjifire/ops/dispatch/sanitize.py
@@ -13,9 +13,32 @@ incident documents (which ultimately flow to NERIS).
 """
 
 import html
+from datetime import datetime
 
 from sjifire.core.pii import redact_pii
 from sjifire.ops.dispatch.models import DispatchCallDocument
+
+
+def _normalize_ts(ts: str) -> str:
+    """Canonicalize an ISO 8601 timestamp for lookup matching.
+
+    The enrichment LLM often drops sub-second precision when echoing
+    timestamps (``2026-02-12T14:38:00.123456`` → ``2026-02-12T14:38:00``)
+    and may normalize ``Z`` suffixes to ``+00:00`` or vice versa.
+    Normalize both sides to second-precision ISO format before using
+    them as dict keys so a minor format mismatch doesn't cause silent
+    regex fallback.
+
+    Falls back to the original string if parsing fails so exact-string
+    matches still work for non-ISO timestamps.
+    """
+    if not ts:
+        return ""
+    try:
+        dt = datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return ts
+    return dt.replace(microsecond=0).isoformat()
 
 
 def sanitize_cad_comments(doc: DispatchCallDocument) -> str:
@@ -101,11 +124,15 @@ def sanitize_dispatch_for_llm(doc: DispatchCallDocument) -> dict:
     if doc.cad_comments or (doc.analysis and doc.analysis.sanitized_cad_comments):
         d["cad_comments"] = sanitize_cad_comments(doc)
 
-    # responder_details: sanitize NOTE radio_log entries
+    # responder_details: sanitize NOTE radio_log entries.
+    # Match sanitized notes back to raw entries by (timestamp, unit).
+    # Normalize timestamps on both sides — see ``_normalize_ts``.
     sanitized_lookup: dict[tuple[str, str], str] = {}
     if doc.analysis and doc.analysis.sanitized_radio_notes:
         sanitized_lookup = {
-            (n.timestamp, n.unit): n.text for n in doc.analysis.sanitized_radio_notes if n.text
+            (_normalize_ts(n.timestamp), n.unit): n.text
+            for n in doc.analysis.sanitized_radio_notes
+            if n.text
         }
 
     for entry in d.get("responder_details", []):
@@ -115,15 +142,22 @@ def sanitize_dispatch_for_llm(doc: DispatchCallDocument) -> dict:
         if not raw_text:
             continue
         key = (
-            str(entry.get("time_of_status_change", "")),
+            _normalize_ts(str(entry.get("time_of_status_change", ""))),
             entry.get("unit_number", ""),
         )
         if key in sanitized_lookup:
-            entry["radio_log"] = sanitized_lookup[key]
+            # LLM output may still carry HTML entities from the source.
+            entry["radio_log"] = html.unescape(sanitized_lookup[key])
         else:
-            entry["radio_log"] = redact_pii(raw_text)
+            # Regex fallback: HTML-decode first so entities like &#32;
+            # don't defeat the \s+ in the age/gender pattern.
+            entry["radio_log"] = redact_pii(html.unescape(raw_text))
 
-    # analysis: safety-net regex pass over text fields
+    # analysis: safety-net regex pass over text fields, plus filter
+    # sanitized_radio_notes to only entries that correspond to real
+    # NOTE entries in responder_details. This guards against the
+    # enrichment LLM fabricating notes — we never surface invented
+    # radio log entries to Claude.
     analysis = d.get("analysis")
     if isinstance(analysis, dict):
         if analysis.get("summary"):
@@ -131,8 +165,19 @@ def sanitize_dispatch_for_llm(doc: DispatchCallDocument) -> dict:
         if analysis.get("short_dsc"):
             analysis["short_dsc"] = redact_pii(analysis["short_dsc"])
         analysis["key_events"] = [redact_pii(e) for e in analysis.get("key_events", [])]
-        # Raw sanitized fields are already clean by construction; no need to
-        # re-process them. They're kept in the dict so callers that want
-        # them explicitly can still access them.
+
+        raw_note_keys = {
+            (
+                _normalize_ts(str(e.get("time_of_status_change", ""))),
+                e.get("unit_number", ""),
+            )
+            for e in d.get("responder_details", [])
+            if e.get("status") == "NOTE"
+        }
+        analysis["sanitized_radio_notes"] = [
+            n
+            for n in analysis.get("sanitized_radio_notes", [])
+            if (_normalize_ts(n.get("timestamp", "")), n.get("unit", "")) in raw_note_keys
+        ]
 
     return d

--- a/src/sjifire/ops/dispatch/tools.py
+++ b/src/sjifire/ops/dispatch/tools.py
@@ -7,6 +7,7 @@ storage) are delegated to ``DispatchStore``.
 import logging
 
 from sjifire.ops.auth import get_current_user
+from sjifire.ops.dispatch.sanitize import sanitize_dispatch_for_llm
 from sjifire.ops.dispatch.store import DispatchStore
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ async def list_dispatch_calls(days: int = 30) -> dict:
             docs = await store.list_recent_with_open()
 
         logger.info("Returning %d dispatch calls", len(docs))
-        return {"calls": [d.to_dict() for d in docs], "count": len(docs)}
+        return {"calls": [sanitize_dispatch_for_llm(d) for d in docs], "count": len(docs)}
     except Exception:
         logger.exception("Failed to list dispatch calls")
         return {"error": "Unable to retrieve dispatch calls. Please try again."}
@@ -70,7 +71,7 @@ async def get_dispatch_call(call_id: str) -> dict:
             if doc is None:
                 return {"error": f"Call not found: {call_id}"}
 
-            result = doc.to_dict()
+            result = sanitize_dispatch_for_llm(doc)
 
             # Include site history from archive
             if doc.address:
@@ -108,7 +109,7 @@ async def get_open_dispatch_calls() -> dict:
             docs = await store.fetch_open()
 
         logger.info("Returning %d open dispatch calls", len(docs))
-        return {"calls": [d.to_dict() for d in docs], "count": len(docs)}
+        return {"calls": [sanitize_dispatch_for_llm(d) for d in docs], "count": len(docs)}
     except Exception:
         logger.exception("Failed to get open dispatch calls")
         return {"error": "Unable to retrieve open calls. Please try again."}
@@ -155,7 +156,7 @@ async def search_dispatch_calls(
             if dispatch_id:
                 doc = await store.get_by_dispatch_id(dispatch_id)
                 if doc:
-                    return {"calls": [doc.to_dict()], "count": 1}
+                    return {"calls": [sanitize_dispatch_for_llm(doc)], "count": 1}
                 return {"calls": [], "count": 0}
 
             # Search by date range
@@ -164,7 +165,7 @@ async def search_dispatch_calls(
 
             docs = await store.list_by_date_range(start_date, end_date)
             return {
-                "calls": [d.to_dict() for d in docs],
+                "calls": [sanitize_dispatch_for_llm(d) for d in docs],
                 "count": len(docs),
             }
     except Exception:

--- a/src/sjifire/ops/incidents/tools.py
+++ b/src/sjifire/ops/incidents/tools.py
@@ -24,6 +24,7 @@ from sjifire.ops.auth import (
     check_is_editor,
     get_current_user,
 )
+from sjifire.ops.dispatch.sanitize import sanitize_cad_comments, sanitize_radio_notes
 from sjifire.ops.incidents.models import (
     ALARM_INFO_KEYS,
     FIRE_DETAIL_KEYS,
@@ -318,24 +319,32 @@ async def _prefill_from_dispatch(incident_number: str) -> dict:
         units.sort(key=lambda u: u.enroute or u.dispatch or "\xff")
         prefill["units"] = units
 
-    # Snapshot dispatch comments (plain string from iSpyFire JoinedComments).
-    # iSpyFire HTML-encodes text (&#x27; for apostrophes, etc.) — decode here.
-    if dispatch.cad_comments:
-        prefill["dispatch_comments"] = html.unescape(dispatch.cad_comments)
+    # Snapshot dispatch comments for the incident document. Incidents are
+    # report-facing (they feed narratives + NERIS submission), so we always
+    # store the LLM-sanitized version. Raw CAD stays on the dispatch record
+    # for human-facing UI surfaces (dashboard, chat sidebar, kiosk).
+    sanitized_cad = sanitize_cad_comments(dispatch)
+    if sanitized_cad:
+        prefill["dispatch_comments"] = sanitized_cad
 
-    # Extract individual NOTE entries for NERIS dispatch.comments
-    notes = _extract_dispatch_notes(dispatch.responder_details)
+    # Build dispatch_notes: parsed CAD timestamp blocks + NOTE radio log
+    # entries, all in sanitized form.
+    notes: list[DispatchNote] = []
 
-    # Parse cad_comments into individual timestamped notes.
-    # The cad_comments blob contains multiple dispatcher entries
-    # separated by timestamp lines; split them so each gets its
-    # own NERIS dispatch.comment entry.
-    if dispatch.cad_comments:
+    if sanitized_cad:
         caller_ts = ""
         if dispatch.time_reported:
             caller_ts = dispatch.time_reported.isoformat()
-        cad_notes = _parse_cad_comments(dispatch.cad_comments, call_ts=caller_ts)
-        notes = cad_notes + notes
+        notes.extend(_parse_cad_comments(sanitized_cad, call_ts=caller_ts))
+
+    notes.extend(
+        DispatchNote(
+            timestamp=n.get("timestamp", ""),
+            unit=n.get("unit", ""),
+            text=n.get("text", ""),
+        )
+        for n in sanitize_radio_notes(dispatch)
+    )
 
     if notes:
         prefill["dispatch_notes"] = notes

--- a/tests/core/test_pii.py
+++ b/tests/core/test_pii.py
@@ -1,12 +1,15 @@
-"""Tests for PII redaction in dispatch logs.
+"""Tests for PII redaction helpers in ``sjifire.core.pii``.
 
-Covers redact_pii() text redaction and redact_dispatch_dict() structural
-redaction for dispatch call dicts.
+Covers ``redact_pii`` text redaction patterns (age+gender, standalone
+age, phone numbers, caller names) plus preservation of operational
+content.  The higher-level LLM-preferred sanitization helpers live in
+``sjifire.ops.dispatch.sanitize`` and are tested in
+``tests/ops/test_dispatch_sanitize.py``.
 """
 
 import pytest
 
-from sjifire.core.pii import redact_dispatch_dict, redact_pii
+from sjifire.core.pii import redact_pii
 
 # ---------------------------------------------------------------------------
 # redact_pii — age + gender patterns
@@ -225,130 +228,3 @@ class TestRedactEdgeCases:
         assert "patient is conscious" in result
 
 
-# ---------------------------------------------------------------------------
-# redact_dispatch_dict — structural redaction
-# ---------------------------------------------------------------------------
-
-
-class TestRedactDispatchDict:
-    def test_redacts_cad_comments(self):
-        d = {"cad_comments": "13yo female injured, callback (360) 555-1234"}
-        result = redact_dispatch_dict(d)
-        assert result["cad_comments"] == "[patient] injured, callback [phone]"
-
-    def test_redacts_responder_radio_log(self):
-        d = {
-            "responder_details": [
-                {"unit_number": "E31", "status": "NOTE", "radio_log": "72yo male fell"},
-                {"unit_number": "M31", "status": "ENRT", "radio_log": "M31 enroute"},
-            ]
-        }
-        result = redact_dispatch_dict(d)
-        assert result["responder_details"][0]["radio_log"] == "[patient] fell"
-        assert result["responder_details"][1]["radio_log"] == "M31 enroute"
-
-    def test_redacts_analysis_summary(self):
-        d = {
-            "analysis": {
-                "summary": "72-year-old male fell from standing position",
-                "short_dsc": "72yo male fall, transported",
-                "key_events": [
-                    "17:05 M31 — pt contact, 13yo female, conscious",
-                    "17:10 BN31 — nothing showing, investigating",
-                ],
-            }
-        }
-        result = redact_dispatch_dict(d)
-        assert "72-year-old" not in result["analysis"]["summary"]
-        assert "[patient]" in result["analysis"]["summary"]
-        assert "72yo" not in result["analysis"]["short_dsc"]
-        assert "13yo" not in result["analysis"]["key_events"][0]
-        # Operational content preserved
-        assert "nothing showing" in result["analysis"]["key_events"][1]
-
-    def test_handles_empty_fields(self):
-        d = {
-            "cad_comments": "",
-            "responder_details": [],
-            "analysis": {"summary": "", "short_dsc": "", "key_events": []},
-        }
-        result = redact_dispatch_dict(d)
-        assert result["cad_comments"] == ""
-        assert result["analysis"]["key_events"] == []
-
-    def test_handles_missing_fields(self):
-        d = {"nature": "Fire Alarm", "address": "100 First St"}
-        result = redact_dispatch_dict(d)
-        assert result == {"nature": "Fire Alarm", "address": "100 First St"}
-
-    def test_handles_no_analysis(self):
-        d = {"cad_comments": "test", "analysis": None}
-        result = redact_dispatch_dict(d)
-        assert result["analysis"] is None
-
-    def test_modifies_in_place(self):
-        d = {"cad_comments": "13yo female injured"}
-        result = redact_dispatch_dict(d)
-        assert result is d  # same object
-        assert d["cad_comments"] == "[patient] injured"
-
-    def test_full_dispatch_dict(self):
-        """Test with a realistic full dispatch dict structure."""
-        d = {
-            "id": "call-uuid-123",
-            "long_term_call_id": "26-001678",
-            "nature": "Medical Aid",
-            "address": "200 Spring St",
-            "city": "Friday Harbor",
-            "state": "WA",
-            "time_reported": "2026-02-12T14:30:00",
-            "geo_location": "48.5343,-123.0170",
-            "cad_comments": "55 y/o male, chest pain, callback (360) 378-5141",
-            "responding_units": "E31,M31",
-            "responder_details": [
-                {
-                    "unit_number": "E31",
-                    "status": "NOTE",
-                    "radio_log": "pt contact, 55yo male, conscious and alert",
-                    "time_of_status_change": "2026-02-12T14:38:00",
-                },
-                {
-                    "unit_number": "M31",
-                    "status": "ENRT",
-                    "radio_log": "M31 enroute w/2",
-                    "time_of_status_change": "2026-02-12T14:31:00",
-                },
-            ],
-            "analysis": {
-                "incident_commander": "BN31",
-                "summary": "55 year old male with chest pain at 200 Spring St",
-                "short_dsc": "55yo male chest pain, transported",
-                "key_events": [
-                    "14:38 E31 — pt contact, 55yo male, alert",
-                    "14:42 M31 — BLS initiated",
-                    "14:50 M31 — transporting to PeaceHealth",
-                ],
-                "patient_count": 1,
-                "outcome": "transported",
-            },
-        }
-        result = redact_dispatch_dict(d)
-
-        # PII stripped
-        assert "55 y/o" not in result["cad_comments"]
-        assert "55yo" not in result["cad_comments"]
-        assert "378-5141" not in result["cad_comments"]
-        assert "55yo" not in result["responder_details"][0]["radio_log"]
-        assert "55 year old" not in result["analysis"]["summary"]
-        assert "55yo" not in result["analysis"]["short_dsc"]
-        assert "55yo" not in result["analysis"]["key_events"][0]
-
-        # Operational content preserved
-        assert result["address"] == "200 Spring St"
-        assert result["nature"] == "Medical Aid"
-        assert "chest pain" in result["cad_comments"]
-        assert "conscious and alert" in result["responder_details"][0]["radio_log"]
-        assert result["responder_details"][1]["radio_log"] == "M31 enroute w/2"
-        assert "BLS initiated" in result["analysis"]["key_events"][1]
-        assert "transporting to PeaceHealth" in result["analysis"]["key_events"][2]
-        assert result["analysis"]["patient_count"] == 1

--- a/tests/core/test_pii.py
+++ b/tests/core/test_pii.py
@@ -308,3 +308,272 @@ class TestRedactPiiRedos:
             redact_pii(text)
 
         assert not any("oversized input" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Known limitations — things the regex does NOT catch (LLM's job)
+# ---------------------------------------------------------------------------
+#
+# Every case in this section is a PII pattern the regex layer is
+# intentionally NOT expected to handle.  These are here as documentation
+# of the boundary between the regex and the LLM layer (per audit item #8).
+#
+# If one of these starts matching due to a regex change, that's worth
+# reviewing: either (a) it's a legitimate improvement — update the test,
+# or (b) the regex got over-broad and may false-positive on operational
+# content — pull back.
+#
+# The LLM enrichment layer is the primary defense for all of these.
+# See ``docs/dispatch-cheatsheet.md`` for the enrichment prompt.
+
+
+class TestRegexKnownLimitations:
+    """Document what the regex layer does NOT catch.
+
+    These cases all rely on the enrichment LLM to detect and strip PII.
+    The regex is intentionally narrow — a deterministic baseline, not a
+    comprehensive detector.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Contextual age words — no digit prefix, can't be caught by a
+            # digit-anchored pattern.  LLM understands "teenage" ≈ age.
+            "teenage girl trapped under car",
+            "teen male unresponsive",
+            "elderly man with chest pain",
+            "elderly woman, difficulty breathing",
+            "middle-aged woman in labor",
+            "young boy choking on food",
+            "young girl with head wound",
+            "infant not breathing",
+            "the child is unresponsive",
+            "senior citizen fall",
+            "juvenile male subject",
+            "pregnant woman in distress",
+            "geriatric patient with altered mental status",
+        ],
+    )
+    def test_contextual_age_words_not_caught(self, text: str):
+        """Contextual demographic words don't match the digit-anchored regex."""
+        assert redact_pii(text) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "male in his 70s",
+            "female in her 80s",
+            "subject in their 50s",
+            "patient in her mid-60s",
+        ],
+    )
+    def test_age_bracket_patterns_not_caught(self, text: str):
+        """'in his/her/their Xs' decade-bracket patterns."""
+        assert redact_pii(text) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Pattern requires singular "year" or "yr" — plurals fall through.
+            "60 years old male",
+            "72 yrs old",
+            "55-years-old female",
+            "88 years old, difficulty breathing",
+            # Months / days / weeks — pattern is year-only
+            "4 month old infant",
+            "6-week-old baby",
+            "3 day old newborn",
+        ],
+    )
+    def test_plural_and_non_year_age_units_not_caught(self, text: str):
+        """Plurals ('years old') and non-year units ('month old') aren't caught."""
+        assert redact_pii(text) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Bare names with no caller/RP prefix — can't distinguish from
+            # street names, dispatcher names, business names.
+            "Jane Doe in custody",
+            "John Smith reported fire",
+            "Bob Jones saw smoke",
+            # Titles with names
+            "Mr. Smith on scene",
+            "Mrs. Jones called",
+            "Dr. Johnson assisting",
+            # Reversed orderings
+            "Smith, John reporting",
+            # Hyphenated first names
+            "Maria-Elena Gonzalez",
+            # Single-letter first name
+            "J. Smith on scene",
+            # Three-word names
+            "John Paul Smith on scene",
+        ],
+    )
+    def test_bare_name_patterns_not_caught(self, text: str):
+        """Only ``caller:`` / ``RP:`` / ``reporting party`` prefixed names are caught.
+
+        Bare names, titles, and reversed orderings are left to the LLM.
+        Regex can't distinguish "John Smith" the caller from "John Smith Rd"
+        the street or "John Smith" the dispatcher.
+        """
+        assert redact_pii(text) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Non-colon introducers after the caller keyword
+            "caller says John Smith was hurt",
+            "caller told us John Smith is safe",
+            "caller indicated John Smith left",
+            # Comma separator
+            "caller, John Smith, reported fire",
+        ],
+    )
+    def test_caller_keyword_without_direct_name_not_caught(self, text: str):
+        """Pattern requires ``caller`` + optional ``:``/``-`` + name directly.
+
+        Intervening words ('says', 'told') or comma separators break
+        the pattern.  These rely on the LLM.
+        """
+        assert redact_pii(text) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "CALLER: JOHN SMITH",  # all-caps name
+            "Caller: JOHN DOE advises",
+            "rp jane doe",  # all-lowercase name
+            "reporting party: john smith",
+        ],
+    )
+    def test_non_titlecase_names_not_caught(self, text: str):
+        """Name capture requires ``[A-Z][a-z]+`` — title-cased only.
+
+        All-caps and all-lowercase names fall through to the LLM.
+        Loosening this is risky — it's what caused the prior bug where
+        'the caller was mad' was being redacted to 'the [caller]'.
+        """
+        assert redact_pii(text) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "call 555-1234",  # 7-digit local, no area code
+            "ext 4142",
+            "extension 555",
+            "3605551234",  # no separators
+            "(360)555-1234",  # no space after paren
+        ],
+    )
+    def test_short_or_mangled_phone_formats_not_caught(self, text: str):
+        """Pattern requires area-code + separator + 3+4 digit structure."""
+        assert redact_pii(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Operational content must NOT be redacted (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestRegexPreservesOperationalContent:
+    """Regression guard: text that LOOKS close to PII patterns but isn't.
+
+    If someone makes the regex more aggressive, these will fail and
+    signal that real operational content is being destroyed.  Most of
+    these are things that actually appear in CAD comments.
+    """
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # "year" without "old" — not an age descriptor
+            "60 year flood zone",
+            "100 year storm warning",
+            "5 year anniversary",
+            "year-round operation",
+            # "old" without a number in age form
+            "Old Farm Rd",
+            "Old Town Hall fire alarm",
+            "year old tradition",  # no digit prefix
+            "years of service",
+            # Digits that aren't ages
+            "Station 31 responding",
+            "Engine 33 enroute",
+            "Unit 42 on scene",
+            "100 block of Main St",
+            "Mile marker 15",
+            "apt 201",
+            # 3-digit numbers in various contexts
+            "911 call",
+            "$500 property damage",
+            "2:30 pm dispatched",
+        ],
+    )
+    def test_near_miss_operational_text_preserved(self, text: str):
+        """Content that looks near a PII pattern but is legitimately operational."""
+        assert redact_pii(text) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Regression for the bug this audit item uncovered:
+            # with the old IGNORECASE-globally pattern, these were being
+            # incorrectly redacted as "[caller] ..." because the name
+            # capture matched any two lowercase words after "caller".
+            "the caller was mad",
+            "after the caller hung up",
+            "caller on line one",
+            "caller says the house is fine",
+            "caller is still on scene",
+            "rp has departed",
+            "reporting party will call back",
+        ],
+    )
+    def test_caller_keyword_in_narrative_not_falsely_redacted(self, text: str):
+        """Regression guard for the caller-regex IGNORECASE over-match bug.
+
+        Before the scoped ``(?i:...)`` fix, ``[A-Z][a-z]+`` with global
+        IGNORECASE matched any two lowercase words after ``caller``, so
+        ``"the caller was mad"`` was being redacted to ``"the [caller]"``.
+        """
+        assert redact_pii(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Accepted false positives — regex DOES catch these, and that's ok
+# ---------------------------------------------------------------------------
+
+
+class TestRegexAcceptedFalsePositives:
+    """Known false positives we accept rather than tightening the regex.
+
+    These are rare in fire/EMS dispatch contexts, and tightening the
+    age pattern to exclude them would risk false negatives on real
+    patient demographics.  Documented here so we know the boundary.
+    """
+
+    def test_animal_ages_get_redacted(self):
+        """'13-year-old dog' is rare in CAD; redacted form is still readable."""
+        # Accepted: "13-year-old" matches the age pattern; "[patient] dog"
+        # is still operationally clear.
+        assert redact_pii("13-year-old dog trapped in well") == "[patient] dog trapped in well"
+
+    def test_building_ages_get_redacted(self):
+        """Building ages in arson/structure reports — rare, acceptable."""
+        result = redact_pii("100-year-old building engulfed")
+        assert "[patient]" in result
+        assert "building engulfed" in result
+
+    def test_four_digit_ages_not_caught(self):
+        r"""4+ digit "ages" are not caught — pattern caps at ``\d{1,3}``.
+
+        This is a hard limit on the age pattern (bounded to prevent
+        matching unrelated number runs).  No realistic human age needs
+        4 digits, so it's fine — but 4-digit "year old" phrasings
+        like "1990 year old vehicle" fall through.
+        """
+        text = "1990 year old vehicle"
+        assert redact_pii(text) == text  # unchanged — no match

--- a/tests/core/test_pii.py
+++ b/tests/core/test_pii.py
@@ -7,6 +7,8 @@ content.  The higher-level LLM-preferred sanitization helpers live in
 ``tests/ops/test_dispatch_sanitize.py``.
 """
 
+import typing
+
 import pytest
 
 from sjifire.core.pii import redact_pii
@@ -228,3 +230,81 @@ class TestRedactEdgeCases:
         assert "patient is conscious" in result
 
 
+# ---------------------------------------------------------------------------
+# ReDoS hardening: empirical linear-time proof + size guard
+# ---------------------------------------------------------------------------
+
+
+class TestRedactPiiRedos:
+    """Guard against catastrophic backtracking on pathological input.
+
+    Our regexes don't have nested quantifiers that would cause true
+    ReDoS, but we keep these tests as empirical proof — if someone
+    refactors the patterns in a way that introduces backtracking, the
+    timing assertion will fail loudly.
+    """
+
+    _PATHOLOGICAL_INPUTS: typing.ClassVar[dict[str, str]] = {
+        # Long runs of the ambiguous separator characters
+        "long-whitespace-run": "13" + " " * 10_000 + "-" + " " * 10_000 + "year old male",
+        "long-dash-run": "13" + "-" * 1_000 + "year" + "-" * 1_000 + "old male",
+        # Long input with no match at all (worst case for naive backtracking)
+        "no-match-long": "a" * 50_000,
+        # Long input where the regex must fail near the end of each span
+        "near-miss-year": "yea" * 10_000,
+        "near-miss-yr": "yr " * 10_000,
+        # Lots of real matches interleaved with noise
+        "many-matches": ("13yo male " + "E31 responding " * 3) * 1_000,
+        # Long phone-like string that ultimately doesn't match
+        "phone-near-miss": "123-456-78" * 5_000,
+        # Long caller-like prefix with no capitalized name follow-up
+        "caller-near-miss": "caller: " * 5_000,
+    }
+
+    @pytest.mark.parametrize("label", list(_PATHOLOGICAL_INPUTS.keys()))
+    def test_pathological_input_completes_quickly(self, label: str):
+        """Every redact_pii call should be well under a second on ~50KB."""
+        import time
+
+        text = self._PATHOLOGICAL_INPUTS[label]
+        start = time.perf_counter()
+        result = redact_pii(text)
+        elapsed = time.perf_counter() - start
+
+        # Generous budget — real-world dispatch CAD blobs are <10KB and
+        # complete in ~1ms. On 50KB pathological input we should still
+        # be well under a second.  If this fails it means someone
+        # introduced backtracking into a pattern.
+        assert elapsed < 1.0, (
+            f"redact_pii too slow on '{label}' ({elapsed:.3f}s) — "
+            f"possible regex backtracking introduced"
+        )
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_very_large_input_logs_warning(self, caplog):
+        """Inputs above the soft cap trigger a canary warning log."""
+        import logging
+
+        text = "a" * 200_001  # one byte over _MAX_INPUT_BYTES
+
+        with caplog.at_level(logging.WARNING, logger="sjifire.core.pii"):
+            result = redact_pii(text)
+
+        assert any("oversized input" in rec.message for rec in caplog.records), (
+            f"expected oversized-input warning, got: {[r.message for r in caplog.records]}"
+        )
+        # Still processed the input — no silent skip
+        assert isinstance(result, str)
+        assert len(result) == len(text)
+
+    def test_input_at_cap_does_not_warn(self, caplog):
+        """Exactly at the cap should not emit a warning."""
+        import logging
+
+        text = "a" * 200_000  # exactly at cap
+
+        with caplog.at_level(logging.WARNING, logger="sjifire.core.pii"):
+            redact_pii(text)
+
+        assert not any("oversized input" in rec.message for rec in caplog.records)

--- a/tests/core/test_pii.py
+++ b/tests/core/test_pii.py
@@ -1,0 +1,354 @@
+"""Tests for PII redaction in dispatch logs.
+
+Covers redact_pii() text redaction and redact_dispatch_dict() structural
+redaction for dispatch call dicts.
+"""
+
+import pytest
+
+from sjifire.core.pii import redact_dispatch_dict, redact_pii
+
+# ---------------------------------------------------------------------------
+# redact_pii — age + gender patterns
+# ---------------------------------------------------------------------------
+
+
+class TestRedactAgeGender:
+    """Age + gender combinations should be replaced with [patient]."""
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            # Standard "yo" forms
+            (
+                "13yo female injured in rear passenger seat",
+                "[patient] injured in rear passenger seat",
+            ),
+            ("9yo male stuck under car", "[patient] stuck under car"),
+            ("72yo male fell from standing position", "[patient] fell from standing position"),
+            # Spaced "y/o" forms
+            ("55 y/o female, conscious and breathing", "[patient], conscious and breathing"),
+            ("3 y/o male having seizure", "[patient] having seizure"),
+            # "year old" forms
+            ("72 year old male who had fallen", "[patient] who had fallen"),
+            ("13-year-old female unresponsive", "[patient] unresponsive"),
+            ("5 year old boy choking", "[patient] choking"),
+            ("88 year old woman, difficulty breathing", "[patient], difficulty breathing"),
+            # "yr old" forms
+            ("45 yr old man with chest pain", "[patient] with chest pain"),
+            ("6-yr-old girl fell off bike", "[patient] fell off bike"),
+            # Abbreviated gender (m/f)
+            ("55yo m with chest pain", "[patient] with chest pain"),
+            ("23yo f unresponsive", "[patient] unresponsive"),
+            # En-dash separator
+            ("72\u2013year\u2013old male", "[patient]"),
+        ],
+    )
+    def test_age_gender_redacted(self, text: str, expected: str):
+        assert redact_pii(text) == expected
+
+    def test_multiple_patients_in_one_line(self):
+        text = "13yo female and 9yo male both injured in vehicle"
+        result = redact_pii(text)
+        assert result == "[patient] and [patient] both injured in vehicle"
+
+    def test_age_gender_case_insensitive(self):
+        assert redact_pii("72YO MALE FELL") == "[patient] FELL"
+        assert redact_pii("13Yo Female injured") == "[patient] injured"
+
+
+# ---------------------------------------------------------------------------
+# redact_pii — standalone age patterns
+# ---------------------------------------------------------------------------
+
+
+class TestRedactStandaloneAge:
+    """Age descriptors without gender should also be replaced."""
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("72yo fell from standing", "[patient] fell from standing"),
+            ("13 y/o having seizure", "[patient] having seizure"),
+            ("5 year old choking", "[patient] choking"),
+            ("88-year-old, difficulty breathing", "[patient], difficulty breathing"),
+            ("45 yr old with chest pain", "[patient] with chest pain"),
+        ],
+    )
+    def test_standalone_age_redacted(self, text: str, expected: str):
+        assert redact_pii(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# redact_pii — phone numbers
+# ---------------------------------------------------------------------------
+
+
+class TestRedactPhoneNumbers:
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("callback (360) 555-1234", "callback [phone]"),
+            ("call 360-555-1234 for info", "call [phone] for info"),
+            ("phone: 360.555.1234", "phone: [phone]"),
+            ("contact 360 555-1234", "contact [phone]"),
+        ],
+    )
+    def test_phone_redacted(self, text: str, expected: str):
+        assert redact_pii(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# redact_pii — caller/RP names
+# ---------------------------------------------------------------------------
+
+
+class TestRedactCallerNames:
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("caller: John Smith on scene", "[caller] on scene"),
+            ("caller John Smith advises false alarm", "[caller] advises false alarm"),
+            ("RP: Jane Doe reports smoke", "[caller] reports smoke"),
+            ("RP Jane Doe called back", "[caller] called back"),
+            ("reporting party: Bob Jones saw flames", "[caller] saw flames"),
+        ],
+    )
+    def test_caller_redacted(self, text: str, expected: str):
+        assert redact_pii(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# redact_pii — preservation of operational content
+# ---------------------------------------------------------------------------
+
+
+class TestPreserveOperational:
+    """Operational dispatch content must NOT be redacted."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Unit codes and station references
+            "E31 dispatched to 200 Spring St",
+            "BN31 has command, est Farm Rd Command",
+            "T33 staging on Cattle Point Rd",
+            "L31 clear, returning to quarters",
+            # Addresses
+            "respond to 589 Old Farm Rd, Friday Harbor",
+            "cross streets: Cattle Point Rd and Pear Point Rd",
+            # Times and timestamps
+            "dispatched at 14:30:15",
+            "on scene at 14:38:22",
+            # Status codes
+            "disp:AMB, oc:MED",
+            "cancel additional resources",
+            # Fire-specific
+            "nothing showing on arrival",
+            "smoke from eaves, fire in chimney",
+            "fire extinguished, overhaul in progress",
+            # General dispatch language
+            "2 calls from on site, advise false alarm",
+            "good codes from on site per alarm company",
+            "key holder en route",
+            # Street numbers (should not be confused with ages)
+            "respond to 123 Main St",
+            "accident at mile marker 42",
+        ],
+    )
+    def test_operational_text_preserved(self, text: str):
+        assert redact_pii(text) == text
+
+
+# ---------------------------------------------------------------------------
+# redact_pii — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRedactEdgeCases:
+    def test_empty_string(self):
+        assert redact_pii("") == ""
+
+    def test_none_returns_none(self):
+        assert redact_pii(None) is None  # type: ignore[arg-type]
+
+    def test_no_pii(self):
+        text = "Engine 31 responded to fire alarm at 100 First St"
+        assert redact_pii(text) == text
+
+    def test_mixed_pii_and_operational(self):
+        text = (
+            "E31 on scene. 13yo female injured in rear passenger seat. "
+            "Callback (360) 555-1234. BN31 has command."
+        )
+        expected = (
+            "E31 on scene. [patient] injured in rear passenger seat. "
+            "Callback [phone]. BN31 has command."
+        )
+        assert redact_pii(text) == expected
+
+    def test_multiline_text(self):
+        text = "13yo male stuck under car\nE31 responding\ncaller: John Smith on scene"
+        expected = "[patient] stuck under car\nE31 responding\n[caller] on scene"
+        assert redact_pii(text) == expected
+
+    def test_html_decoded_apostrophes(self):
+        """PII in text with decoded HTML entities."""
+        text = "72yo male at patient's residence, can't walk"
+        expected = "[patient] at patient's residence, can't walk"
+        assert redact_pii(text) == expected
+
+    def test_real_cad_comment_block(self):
+        """Realistic multi-line CAD comment block."""
+        text = (
+            "18:56:01 02/02/2026 - M Rennick\n"
+            "13yo female passenger, possible head injury\n"
+            "18:57:30 02/02/2026 - M Rennick\n"
+            "caller: John Smith says patient is conscious\n"
+            "callback (360) 378-4141\n"
+            "19:01:00 02/02/2026 - Dispatch\n"
+            "E31 on scene, BN31 has command"
+        )
+        result = redact_pii(text)
+        # Age+gender redacted
+        assert "13yo" not in result
+        assert "female" not in result
+        # Caller name redacted
+        assert "John Smith" not in result
+        # Phone redacted
+        assert "378-4141" not in result
+        # Operational content preserved
+        assert "M Rennick" in result  # dispatcher name (not caller/patient)
+        assert "E31 on scene" in result
+        assert "BN31 has command" in result
+        assert "possible head injury" in result  # medical condition preserved
+        assert "patient is conscious" in result
+
+
+# ---------------------------------------------------------------------------
+# redact_dispatch_dict — structural redaction
+# ---------------------------------------------------------------------------
+
+
+class TestRedactDispatchDict:
+    def test_redacts_cad_comments(self):
+        d = {"cad_comments": "13yo female injured, callback (360) 555-1234"}
+        result = redact_dispatch_dict(d)
+        assert result["cad_comments"] == "[patient] injured, callback [phone]"
+
+    def test_redacts_responder_radio_log(self):
+        d = {
+            "responder_details": [
+                {"unit_number": "E31", "status": "NOTE", "radio_log": "72yo male fell"},
+                {"unit_number": "M31", "status": "ENRT", "radio_log": "M31 enroute"},
+            ]
+        }
+        result = redact_dispatch_dict(d)
+        assert result["responder_details"][0]["radio_log"] == "[patient] fell"
+        assert result["responder_details"][1]["radio_log"] == "M31 enroute"
+
+    def test_redacts_analysis_summary(self):
+        d = {
+            "analysis": {
+                "summary": "72-year-old male fell from standing position",
+                "short_dsc": "72yo male fall, transported",
+                "key_events": [
+                    "17:05 M31 — pt contact, 13yo female, conscious",
+                    "17:10 BN31 — nothing showing, investigating",
+                ],
+            }
+        }
+        result = redact_dispatch_dict(d)
+        assert "72-year-old" not in result["analysis"]["summary"]
+        assert "[patient]" in result["analysis"]["summary"]
+        assert "72yo" not in result["analysis"]["short_dsc"]
+        assert "13yo" not in result["analysis"]["key_events"][0]
+        # Operational content preserved
+        assert "nothing showing" in result["analysis"]["key_events"][1]
+
+    def test_handles_empty_fields(self):
+        d = {
+            "cad_comments": "",
+            "responder_details": [],
+            "analysis": {"summary": "", "short_dsc": "", "key_events": []},
+        }
+        result = redact_dispatch_dict(d)
+        assert result["cad_comments"] == ""
+        assert result["analysis"]["key_events"] == []
+
+    def test_handles_missing_fields(self):
+        d = {"nature": "Fire Alarm", "address": "100 First St"}
+        result = redact_dispatch_dict(d)
+        assert result == {"nature": "Fire Alarm", "address": "100 First St"}
+
+    def test_handles_no_analysis(self):
+        d = {"cad_comments": "test", "analysis": None}
+        result = redact_dispatch_dict(d)
+        assert result["analysis"] is None
+
+    def test_modifies_in_place(self):
+        d = {"cad_comments": "13yo female injured"}
+        result = redact_dispatch_dict(d)
+        assert result is d  # same object
+        assert d["cad_comments"] == "[patient] injured"
+
+    def test_full_dispatch_dict(self):
+        """Test with a realistic full dispatch dict structure."""
+        d = {
+            "id": "call-uuid-123",
+            "long_term_call_id": "26-001678",
+            "nature": "Medical Aid",
+            "address": "200 Spring St",
+            "city": "Friday Harbor",
+            "state": "WA",
+            "time_reported": "2026-02-12T14:30:00",
+            "geo_location": "48.5343,-123.0170",
+            "cad_comments": "55 y/o male, chest pain, callback (360) 378-5141",
+            "responding_units": "E31,M31",
+            "responder_details": [
+                {
+                    "unit_number": "E31",
+                    "status": "NOTE",
+                    "radio_log": "pt contact, 55yo male, conscious and alert",
+                    "time_of_status_change": "2026-02-12T14:38:00",
+                },
+                {
+                    "unit_number": "M31",
+                    "status": "ENRT",
+                    "radio_log": "M31 enroute w/2",
+                    "time_of_status_change": "2026-02-12T14:31:00",
+                },
+            ],
+            "analysis": {
+                "incident_commander": "BN31",
+                "summary": "55 year old male with chest pain at 200 Spring St",
+                "short_dsc": "55yo male chest pain, transported",
+                "key_events": [
+                    "14:38 E31 — pt contact, 55yo male, alert",
+                    "14:42 M31 — BLS initiated",
+                    "14:50 M31 — transporting to PeaceHealth",
+                ],
+                "patient_count": 1,
+                "outcome": "transported",
+            },
+        }
+        result = redact_dispatch_dict(d)
+
+        # PII stripped
+        assert "55 y/o" not in result["cad_comments"]
+        assert "55yo" not in result["cad_comments"]
+        assert "378-5141" not in result["cad_comments"]
+        assert "55yo" not in result["responder_details"][0]["radio_log"]
+        assert "55 year old" not in result["analysis"]["summary"]
+        assert "55yo" not in result["analysis"]["short_dsc"]
+        assert "55yo" not in result["analysis"]["key_events"][0]
+
+        # Operational content preserved
+        assert result["address"] == "200 Spring St"
+        assert result["nature"] == "Medical Aid"
+        assert "chest pain" in result["cad_comments"]
+        assert "conscious and alert" in result["responder_details"][0]["radio_log"]
+        assert result["responder_details"][1]["radio_log"] == "M31 enroute w/2"
+        assert "BLS initiated" in result["analysis"]["key_events"][1]
+        assert "transporting to PeaceHealth" in result["analysis"]["key_events"][2]
+        assert result["analysis"]["patient_count"] == 1

--- a/tests/ops/test_chat_engine.py
+++ b/tests/ops/test_chat_engine.py
@@ -634,6 +634,98 @@ class TestSlimDispatchContext:
         assert "agency_code" not in data
         assert "zone_code" not in data
 
+    async def test_dispatch_cad_comments_are_sanitized(self):
+        """Regression: the slim dispatch cad_comments must be sanitized.
+
+        Guards against the chat engine accidentally dropping its
+        ``sanitize_cad_comments`` call. Uses raw PII-bearing CAD and
+        a populated ``sanitized_cad_comments`` LLM field; the slim
+        dict must carry the sanitized version, not the raw.
+        """
+        from sjifire.ops.chat.engine import _fetch_context
+        from sjifire.ops.dispatch.models import (
+            DispatchAnalysis,
+            DispatchCallDocument,
+            SanitizedNote,
+        )
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.incidents.models import IncidentDocument
+
+        incident = IncidentDocument(
+            id="test-inc-pii",
+            incident_number="26-008888",
+            incident_datetime="2026-02-15T00:00:00+00:00",
+            created_by="test@sjifire.org",
+            station="S31",
+        )
+        async with IncidentStore() as store:
+            await store.create(incident)
+
+        dispatch = DispatchCallDocument(
+            id="dispatch-uuid-pii",
+            year="2026",
+            long_term_call_id="26-008888",
+            nature="Medical Aid",
+            address="200 Spring St",
+            agency_code="SJF3",
+            responding_units="E31, M31",
+            responder_details=[
+                {
+                    "unit_number": "E31",
+                    "agency_code": "SJF3",
+                    "status": "NOTE",
+                    "time_of_status_change": "2026-02-15T14:38:00",
+                    "radio_log": "pt contact 13yo female, conscious",
+                },
+            ],
+            cad_comments=(
+                "13yo female passenger injured\ncallback (360) 555-1234\ncaller: John Smith advises"
+            ),
+            geo_location="48.53,-123.01",
+            analysis=DispatchAnalysis(
+                incident_commander="BN31",
+                summary="Medical aid at 200 Spring St, patient transported.",
+                sanitized_cad_comments=(
+                    "the patient injured\ncallback [phone]\nthe caller advises"
+                ),
+                sanitized_radio_notes=[
+                    SanitizedNote(
+                        timestamp="2026-02-15T14:38:00",
+                        unit="E31",
+                        text="pt contact the patient, conscious",
+                    ),
+                ],
+            ),
+        )
+        DispatchStore._memory[dispatch.id] = dispatch.to_cosmos()
+
+        with (
+            patch(
+                "sjifire.ops.schedule.tools.get_on_duty_crew",
+                return_value={"crew": [], "count": 0},
+            ),
+            patch(
+                "sjifire.ops.personnel.tools.get_operational_personnel",
+                return_value=[],
+            ),
+        ):
+            _, dispatch_json, _, _, _ = await _fetch_context("test-inc-pii", _TEST_USER)
+
+        # The entire slim dispatch JSON going to Claude must NOT contain raw PII
+        assert "13yo" not in dispatch_json
+        assert "female" not in dispatch_json
+        assert "555-1234" not in dispatch_json
+        assert "John Smith" not in dispatch_json
+
+        # And it SHOULD contain the sanitized replacements
+        data = json.loads(dispatch_json)
+        assert "the patient" in data["cad_comments"]
+        assert "[phone]" in data["cad_comments"]
+        assert "the caller" in data["cad_comments"]
+
+        # Address still present — not PII
+        assert data["address"] == "200 Spring St"
+
 
 class TestFormatUnitTimesTable:
     """Verify _format_unit_times_table produces a readable table."""

--- a/tests/ops/test_dispatch_enrich.py
+++ b/tests/ops/test_dispatch_enrich.py
@@ -1,0 +1,300 @@
+"""Tests for ``sjifire.ops.dispatch.enrich``.
+
+Focuses on the PII safety net (``_scrub_llm_output``) and its integration
+with ``enrich_dispatch``. The LLM-calling layer is covered by
+``test_dispatch_analysis.py``.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sjifire.ops.dispatch.enrich import _scrub_llm_output, enrich_dispatch
+from sjifire.ops.dispatch.models import (
+    CrewOnDuty,
+    DispatchAnalysis,
+    DispatchCallDocument,
+    SanitizedNote,
+    UnitTiming,
+)
+from tests.factories import DispatchCallDocumentFactory
+
+# ---------------------------------------------------------------------------
+# _scrub_llm_output
+# ---------------------------------------------------------------------------
+
+
+class TestScrubLlmOutput:
+    """The regex safety net catches PII the LLM missed or echoed."""
+
+    def test_scrubs_summary(self):
+        analysis = DispatchAnalysis(summary="13yo female fell from bike")
+        _scrub_llm_output(analysis)
+        assert "13yo" not in analysis.summary
+        assert "[patient]" in analysis.summary
+
+    def test_scrubs_short_dsc(self):
+        analysis = DispatchAnalysis(short_dsc="72yo male fall, transported")
+        _scrub_llm_output(analysis)
+        assert "72yo" not in analysis.short_dsc
+
+    def test_scrubs_outcome(self):
+        analysis = DispatchAnalysis(outcome="transported 55yo female to PeaceHealth")
+        _scrub_llm_output(analysis)
+        assert "55yo" not in analysis.outcome
+        assert "PeaceHealth" in analysis.outcome
+
+    def test_scrubs_actions_taken(self):
+        analysis = DispatchAnalysis(
+            actions_taken=[
+                "Forced entry",
+                "BLS assessment on 72yo male patient",
+                "Applied water",
+            ]
+        )
+        _scrub_llm_output(analysis)
+        assert "72yo" not in analysis.actions_taken[1]
+        assert "BLS assessment" in analysis.actions_taken[1]
+
+    def test_scrubs_key_events(self):
+        analysis = DispatchAnalysis(
+            key_events=[
+                "14:38 E31 — nothing showing",
+                "14:40 M31 — pt contact, 13yo female, conscious",
+            ]
+        )
+        _scrub_llm_output(analysis)
+        assert "13yo" not in analysis.key_events[1]
+        assert analysis.key_events[0] == "14:38 E31 — nothing showing"
+
+    def test_scrubs_sanitized_cad_comments(self):
+        analysis = DispatchAnalysis(
+            sanitized_cad_comments=(
+                "18:56:01 02/12/2026 - M Rennick\n"
+                "13yo female passenger, possible injury\n"
+                "callback (360) 555-1234"
+            )
+        )
+        _scrub_llm_output(analysis)
+        assert "13yo" not in analysis.sanitized_cad_comments
+        assert "555-1234" not in analysis.sanitized_cad_comments
+        assert "M Rennick" in analysis.sanitized_cad_comments  # not PII
+        assert "[patient]" in analysis.sanitized_cad_comments
+        assert "[phone]" in analysis.sanitized_cad_comments
+
+    def test_scrubs_sanitized_radio_notes(self):
+        analysis = DispatchAnalysis(
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact 13yo female, alert",
+                ),
+                SanitizedNote(
+                    timestamp="2026-02-12T14:42:00",
+                    unit="M31",
+                    text="transporting 72yo male to PeaceHealth",
+                ),
+            ]
+        )
+        _scrub_llm_output(analysis)
+        assert "13yo" not in analysis.sanitized_radio_notes[0].text
+        assert "72yo" not in analysis.sanitized_radio_notes[1].text
+        # Timestamp + unit preserved
+        assert analysis.sanitized_radio_notes[0].unit == "E31"
+        assert analysis.sanitized_radio_notes[1].timestamp == "2026-02-12T14:42:00"
+
+    def test_idempotent_on_clean_input(self):
+        """Running scrub twice should produce the same result."""
+        analysis = DispatchAnalysis(
+            summary="the patient fell from standing",
+            short_dsc="patient fall, transported",
+            outcome="transported to PeaceHealth",
+            actions_taken=["BLS assessment", "Transport"],
+            key_events=["14:38 E31 — nothing showing"],
+            sanitized_cad_comments="the patient injured, callback [phone]",
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact the patient",
+                ),
+            ],
+        )
+        # Snapshot before
+        before = analysis.model_dump()
+
+        _scrub_llm_output(analysis)
+        _scrub_llm_output(analysis)  # second pass — must not change anything
+
+        after = analysis.model_dump()
+        assert before == after
+
+    def test_does_not_touch_deterministic_fields(self):
+        """Scrub must leave code-derived fields (unit_times, crew, etc.) alone."""
+        analysis = DispatchAnalysis(
+            incident_commander="BN31",
+            incident_commander_name="Kyle Dodd",
+            alarm_time="2026-02-12T14:30:00",
+            first_enroute="2026-02-12T14:32:00",
+            patient_count=1,
+            escalated=True,
+            unit_times=[
+                UnitTiming(
+                    unit="E31",
+                    paged="2026-02-12T14:30:00",
+                    enroute="2026-02-12T14:32:00",
+                    arrived="2026-02-12T14:38:00",
+                )
+            ],
+            on_duty_crew=[
+                CrewOnDuty(name="Kyle Dodd", position="Battalion Chief", section="Chief Officer")
+            ],
+        )
+        before = analysis.model_dump()
+
+        _scrub_llm_output(analysis)
+
+        after = analysis.model_dump()
+        # These fields are untouched by the safety net
+        for field in (
+            "incident_commander",
+            "incident_commander_name",
+            "alarm_time",
+            "first_enroute",
+            "patient_count",
+            "escalated",
+            "unit_times",
+            "on_duty_crew",
+        ):
+            assert before[field] == after[field], f"field {field} was modified"
+
+    def test_empty_analysis_unchanged(self):
+        """Scrubbing an empty analysis is a no-op."""
+        analysis = DispatchAnalysis()
+        _scrub_llm_output(analysis)
+
+        assert analysis.summary == ""
+        assert analysis.sanitized_cad_comments == ""
+        assert analysis.sanitized_radio_notes == []
+        assert analysis.key_events == []
+
+    def test_handles_empty_text_in_sanitized_radio_notes(self):
+        """Notes with empty text still pass through (scrub is a no-op on empty)."""
+        analysis = DispatchAnalysis(
+            sanitized_radio_notes=[
+                SanitizedNote(timestamp="2026-02-12T14:38:00", unit="E31", text=""),
+            ]
+        )
+        _scrub_llm_output(analysis)
+        assert analysis.sanitized_radio_notes[0].text == ""
+        # Structure preserved
+        assert len(analysis.sanitized_radio_notes) == 1
+
+
+# ---------------------------------------------------------------------------
+# enrich_dispatch integration — safety net catches LLM slippage
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichDispatchSafetyNet:
+    """End-to-end: a leaky LLM response should be scrubbed by enrich_dispatch."""
+
+    @pytest.fixture
+    def doc(self) -> DispatchCallDocument:
+        return DispatchCallDocumentFactory.build(
+            nature="Medical Aid",
+            address="200 Spring St",
+            responder_details=[],
+            cad_comments="13yo female passenger, possible head injury",
+        )
+
+    async def test_leaky_llm_output_is_scrubbed(self, doc):
+        """Leaky LLM output should be scrubbed by the enrichment safety net.
+
+        Simulates an LLM that ignored the 'no PII' instructions and
+        echoed patient demographics into its sanitized_* output.
+        """
+        leaky_analysis = DispatchAnalysis(
+            incident_commander="BN31",
+            summary="13yo female fell and was transported",
+            short_dsc="13yo fall, transported",
+            outcome="transported 13yo female",
+            actions_taken=["BLS on 13yo female"],
+            key_events=["14:38 M31 — pt contact, 13yo female, alert"],
+            # The LLM echoed raw CAD back verbatim (bad)
+            sanitized_cad_comments="13yo female passenger, possible head injury",
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact 13yo female",
+                )
+            ],
+        )
+
+        with (
+            patch(
+                "sjifire.ops.dispatch.analysis.analyze_dispatch",
+                new_callable=AsyncMock,
+                return_value=leaky_analysis,
+            ),
+            patch(
+                "sjifire.ops.dispatch.enrich._get_on_duty_entries",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await enrich_dispatch(doc)
+
+        # Every LLM-authored field must have the 13yo leak stripped
+        assert "13yo" not in result.summary
+        assert "13yo" not in result.short_dsc
+        assert "13yo" not in result.outcome
+        assert "13yo" not in result.actions_taken[0]
+        assert "13yo" not in result.key_events[0]
+        assert "13yo" not in result.sanitized_cad_comments
+        assert "13yo" not in result.sanitized_radio_notes[0].text
+
+        # Operational content still present
+        assert "[patient]" in result.summary
+        assert "transported" in result.outcome
+        assert "BLS" in result.actions_taken[0]
+        assert "M31" in result.key_events[0]
+
+    async def test_clean_llm_output_unchanged(self, doc):
+        """A well-behaved LLM response should pass through unchanged."""
+        clean_analysis = DispatchAnalysis(
+            incident_commander="BN31",
+            summary="Patient fall at 200 Spring St, transported.",
+            short_dsc="patient fall, transported",
+            outcome="transported",
+            actions_taken=["BLS assessment", "Transport to PeaceHealth"],
+            key_events=["14:38 M31 — pt contact, alert"],
+            sanitized_cad_comments="the patient injured, callback [phone]",
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact the patient",
+                )
+            ],
+        )
+
+        with (
+            patch(
+                "sjifire.ops.dispatch.analysis.analyze_dispatch",
+                new_callable=AsyncMock,
+                return_value=clean_analysis,
+            ),
+            patch(
+                "sjifire.ops.dispatch.enrich._get_on_duty_entries",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await enrich_dispatch(doc)
+
+        assert result.summary == "Patient fall at 200 Spring St, transported."
+        assert result.sanitized_cad_comments == "the patient injured, callback [phone]"
+        assert result.sanitized_radio_notes[0].text == "pt contact the patient"

--- a/tests/ops/test_dispatch_enrich.py
+++ b/tests/ops/test_dispatch_enrich.py
@@ -193,6 +193,155 @@ class TestScrubLlmOutput:
 
 
 # ---------------------------------------------------------------------------
+# Instrumentation — structured logs feed issue #93 leak-rate measurement
+# ---------------------------------------------------------------------------
+
+
+class TestScrubLlmOutputInstrumentation:
+    """Structured logging fires when regex catches LLM leaks.
+
+    The safety net should emit a single structured WARNING log per
+    enrichment with the dispatch_id and list of field names that
+    changed.  NEVER the raw text — that's PII by definition.
+    """
+
+    def test_no_log_when_output_is_clean(self, caplog):
+        import logging
+
+        analysis = DispatchAnalysis(
+            summary="the patient fell from standing",
+            short_dsc="patient fall, transported",
+            sanitized_cad_comments="the patient injured",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="sjifire.ops.dispatch.enrich"):
+            _scrub_llm_output(analysis, dispatch_id="26-001678")
+
+        # No safety-net log should fire — output was already clean
+        assert not any("pii_safety_net_triggered" in rec.message for rec in caplog.records)
+
+    def test_logs_when_summary_leaks(self, caplog):
+        import logging
+
+        analysis = DispatchAnalysis(summary="13yo female fell")
+
+        with caplog.at_level(logging.WARNING, logger="sjifire.ops.dispatch.enrich"):
+            _scrub_llm_output(analysis, dispatch_id="26-001678")
+
+        leak_logs = [r for r in caplog.records if "pii_safety_net_triggered" in r.message]
+        assert len(leak_logs) == 1
+        log = leak_logs[0]
+        assert "26-001678" in log.message
+        assert "summary" in log.message
+        assert log.levelname == "WARNING"
+
+    def test_logs_multiple_changed_fields(self, caplog):
+        import logging
+
+        analysis = DispatchAnalysis(
+            summary="13yo female fell",
+            short_dsc="13yo fall",
+            sanitized_cad_comments="13yo female passenger",
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact 13yo female",
+                )
+            ],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="sjifire.ops.dispatch.enrich"):
+            _scrub_llm_output(analysis, dispatch_id="26-001678")
+
+        leak_logs = [r for r in caplog.records if "pii_safety_net_triggered" in r.message]
+        assert len(leak_logs) == 1, "should emit exactly one log per enrichment, not per field"
+        msg = leak_logs[0].message
+        # All four changed fields should be mentioned
+        for field in ("summary", "short_dsc", "sanitized_cad_comments", "sanitized_radio_notes"):
+            assert field in msg, f"expected {field} in log message: {msg}"
+
+    def test_log_does_not_contain_raw_pii(self, caplog):
+        """CRITICAL: the log message must never include the raw PII text."""
+        import logging
+
+        analysis = DispatchAnalysis(
+            summary="13yo female patient named Jane Doe at 360-555-1234",
+            sanitized_cad_comments="caller John Smith advises 72yo male injured",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="sjifire.ops.dispatch.enrich"):
+            _scrub_llm_output(analysis, dispatch_id="26-001678")
+
+        # Every log record — message AND its positional args — must
+        # exclude the raw PII tokens.  caplog.records holds the raw
+        # LogRecord objects; rec.message is post-format, rec.args is
+        # the tuple of values passed to the logger.
+        parts: list[str] = []
+        for rec in caplog.records:
+            parts.append(rec.message)
+            parts.append(rec.getMessage())
+            if rec.args:
+                parts.extend(str(a) for a in rec.args)
+        all_log_text = " ".join(parts)
+
+        assert "Jane Doe" not in all_log_text
+        assert "John Smith" not in all_log_text
+        assert "555-1234" not in all_log_text
+        assert "13yo" not in all_log_text
+        assert "72yo" not in all_log_text
+        assert "female" not in all_log_text
+        assert "male" not in all_log_text
+
+    def test_logs_unknown_when_dispatch_id_missing(self, caplog):
+        """Dispatch ID is optional; log should fall back gracefully."""
+        import logging
+
+        analysis = DispatchAnalysis(summary="13yo female fell")
+
+        with caplog.at_level(logging.WARNING, logger="sjifire.ops.dispatch.enrich"):
+            _scrub_llm_output(analysis)  # no dispatch_id
+
+        leak_logs = [r for r in caplog.records if "pii_safety_net_triggered" in r.message]
+        assert len(leak_logs) == 1
+        assert "(unknown)" in leak_logs[0].message
+
+    async def test_enrich_dispatch_passes_long_term_call_id_to_scrub(self, caplog):
+        """Leak logs are correlatable to the originating dispatch call.
+
+        End-to-end verification that ``enrich_dispatch`` passes
+        ``doc.long_term_call_id`` into the safety net.
+        """
+        import logging
+
+        doc = DispatchCallDocumentFactory.build(
+            long_term_call_id="26-999001",
+            responder_details=[],
+            cad_comments="13yo female",
+        )
+        leaky = DispatchAnalysis(summary="13yo female fell")
+
+        with (
+            patch(
+                "sjifire.ops.dispatch.analysis.analyze_dispatch",
+                new_callable=AsyncMock,
+                return_value=leaky,
+            ),
+            patch(
+                "sjifire.ops.dispatch.enrich._get_on_duty_entries",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            caplog.at_level(logging.WARNING, logger="sjifire.ops.dispatch.enrich"),
+        ):
+            await enrich_dispatch(doc)
+
+        leak_logs = [r for r in caplog.records if "pii_safety_net_triggered" in r.message]
+        assert len(leak_logs) >= 1
+        assert "26-999001" in leak_logs[0].message
+
+
+# ---------------------------------------------------------------------------
 # enrich_dispatch integration — safety net catches LLM slippage
 # ---------------------------------------------------------------------------
 

--- a/tests/ops/test_dispatch_sanitize.py
+++ b/tests/ops/test_dispatch_sanitize.py
@@ -1,0 +1,659 @@
+"""Tests for LLM-facing dispatch sanitization helpers.
+
+Covers:
+
+- ``sanitize_cad_comments`` — prefers LLM-sanitized field, falls back to regex
+- ``sanitize_radio_notes`` — prefers LLM-sanitized notes, falls back to regex
+- ``sanitize_dispatch_for_llm`` — full dict shape for MCP tool output
+- End-to-end wiring via ``_prefill_from_dispatch`` (incident creation)
+- End-to-end wiring via chat engine slim dict
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sjifire.ops.dispatch.models import (
+    DispatchAnalysis,
+    DispatchCallDocument,
+    SanitizedNote,
+)
+from sjifire.ops.dispatch.sanitize import (
+    sanitize_cad_comments,
+    sanitize_dispatch_for_llm,
+    sanitize_radio_notes,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_doc(**overrides) -> DispatchCallDocument:
+    """Build a DispatchCallDocument with raw PII-bearing content by default."""
+    defaults = {
+        "id": "call-uuid-123",
+        "year": "2026",
+        "long_term_call_id": "26-001678",
+        "nature": "Medical Aid",
+        "address": "200 Spring St",
+        "agency_code": "SJF",
+        "type": "EMS",
+        "zone_code": "Z1",
+        "time_reported": datetime(2026, 2, 12, 14, 30),
+        "is_completed": True,
+        "cad_comments": (
+            "18:56:01 02/12/2026 - M Rennick\n"
+            "13yo female passenger, possible head injury\n"
+            "callback (360) 378-4141\n"
+            "18:57:30 02/12/2026 - M Rennick\n"
+            "caller: John Smith says patient is conscious"
+        ),
+        "responding_units": "E31,M31",
+        "responder_details": [
+            {
+                "unit_number": "E31",
+                "agency_code": "SJF",
+                "status": "NOTE",
+                "time_of_status_change": "2026-02-12T14:38:00",
+                "radio_log": "pt contact 13yo female, conscious and alert",
+            },
+            {
+                "unit_number": "M31",
+                "agency_code": "SJF",
+                "status": "ENRT",
+                "time_of_status_change": "2026-02-12T14:31:00",
+                "radio_log": "M31 enroute w/2",
+            },
+            {
+                "unit_number": "M31",
+                "agency_code": "SJF",
+                "status": "NOTE",
+                "time_of_status_change": "2026-02-12T14:42:00",
+                "radio_log": "transporting 72yo male to PeaceHealth",
+            },
+        ],
+        "city": "Friday Harbor",
+        "state": "WA",
+        "zip_code": "98250",
+        "geo_location": "48.5343,-123.0170",
+    }
+    defaults.update(overrides)
+    return DispatchCallDocument(**defaults)
+
+
+def _make_analysis(**overrides) -> DispatchAnalysis:
+    """Build a DispatchAnalysis with LLM-sanitized fields populated."""
+    defaults = {
+        "incident_commander": "BN31",
+        "summary": "Medical aid call at 200 Spring St, patient transported.",
+        "short_dsc": "patient fall, transported",
+        "key_events": ["14:38 E31 — pt contact, alert"],
+        "sanitized_cad_comments": (
+            "18:56:01 02/12/2026 - M Rennick\n"
+            "the patient, possible head injury\n"
+            "callback [phone]\n"
+            "18:57:30 02/12/2026 - M Rennick\n"
+            "the caller says the patient is conscious"
+        ),
+        "sanitized_radio_notes": [
+            SanitizedNote(
+                timestamp="2026-02-12T14:38:00",
+                unit="E31",
+                text="pt contact the patient, conscious and alert",
+            ),
+            SanitizedNote(
+                timestamp="2026-02-12T14:42:00",
+                unit="M31",
+                text="transporting the patient to PeaceHealth",
+            ),
+        ],
+    }
+    defaults.update(overrides)
+    return DispatchAnalysis(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# sanitize_cad_comments
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeCadComments:
+    def test_prefers_llm_sanitized_when_present(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        result = sanitize_cad_comments(doc)
+
+        assert "the patient, possible head injury" in result
+        assert "the caller says the patient" in result
+        # Raw PII should NOT appear
+        assert "13yo" not in result
+        assert "John Smith" not in result
+        assert "378-4141" not in result
+        # Operational content preserved
+        assert "M Rennick" in result  # dispatcher name is not PII
+        assert "02/12/2026" in result
+
+    def test_falls_back_to_regex_when_no_analysis(self):
+        doc = _make_doc()
+        doc.analysis = DispatchAnalysis()  # empty
+
+        result = sanitize_cad_comments(doc)
+
+        # Regex redaction should have caught these
+        assert "13yo female" not in result
+        assert "(360) 378-4141" not in result
+        assert "[patient]" in result
+        assert "[phone]" in result
+        # Dispatcher header preserved
+        assert "M Rennick" in result
+
+    def test_falls_back_to_regex_when_sanitized_empty_string(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis(sanitized_cad_comments="")
+
+        result = sanitize_cad_comments(doc)
+
+        assert "[patient]" in result  # regex path
+
+    def test_returns_empty_when_no_cad_comments(self):
+        doc = _make_doc(cad_comments="")
+        doc.analysis = DispatchAnalysis()
+
+        assert sanitize_cad_comments(doc) == ""
+
+    def test_html_entities_decoded_in_llm_sanitized(self):
+        """HTML entities in sanitized field should still be decoded."""
+        doc = _make_doc()
+        doc.analysis = _make_analysis(sanitized_cad_comments="caller&#x27;s phone was ringing")
+
+        result = sanitize_cad_comments(doc)
+
+        assert result == "caller's phone was ringing"
+
+    def test_html_entities_decoded_in_regex_fallback(self):
+        doc = _make_doc(cad_comments="patient&#x27;s door was locked")
+        doc.analysis = DispatchAnalysis()
+
+        result = sanitize_cad_comments(doc)
+
+        assert "patient's door" in result
+
+
+# ---------------------------------------------------------------------------
+# sanitize_radio_notes
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeRadioNotes:
+    def test_prefers_llm_sanitized_notes(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        notes = sanitize_radio_notes(doc)
+
+        assert len(notes) == 2
+        assert notes[0]["timestamp"] == "2026-02-12T14:38:00"
+        assert notes[0]["unit"] == "E31"
+        assert "the patient" in notes[0]["text"]
+        assert "13yo" not in notes[0]["text"]
+        assert "72yo" not in notes[1]["text"]
+        assert "PeaceHealth" in notes[1]["text"]
+
+    def test_falls_back_to_regex_from_responder_details(self):
+        doc = _make_doc()
+        doc.analysis = DispatchAnalysis()  # no sanitized notes
+
+        notes = sanitize_radio_notes(doc)
+
+        # Should extract the 2 NOTE-status entries, skipping ENRT
+        assert len(notes) == 2
+        # Both should be regex-redacted
+        for note in notes:
+            assert "13yo" not in note["text"]
+            assert "72yo" not in note["text"]
+            assert "[patient]" in note["text"]
+        # Unit + timestamp preserved
+        units = {n["unit"] for n in notes}
+        assert units == {"E31", "M31"}
+
+    def test_fallback_skips_non_note_entries(self):
+        doc = _make_doc()
+        doc.analysis = DispatchAnalysis()
+
+        notes = sanitize_radio_notes(doc)
+
+        # ENRT entry should be skipped — only 2 NOTE entries
+        assert len(notes) == 2
+        assert all(n["text"] for n in notes)
+        # None of the notes should be the ENRT radio_log
+        assert not any("enroute w/2" in n["text"] for n in notes)
+
+    def test_fallback_skips_empty_radio_log(self):
+        doc = _make_doc(
+            responder_details=[
+                {
+                    "unit_number": "E31",
+                    "status": "NOTE",
+                    "time_of_status_change": "2026-02-12T14:38:00",
+                    "radio_log": "",
+                },
+                {
+                    "unit_number": "M31",
+                    "status": "NOTE",
+                    "time_of_status_change": "2026-02-12T14:42:00",
+                    "radio_log": "   ",
+                },
+            ]
+        )
+        doc.analysis = DispatchAnalysis()
+
+        assert sanitize_radio_notes(doc) == []
+
+    def test_empty_sanitized_notes_list_falls_back(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis(sanitized_radio_notes=[])
+
+        notes = sanitize_radio_notes(doc)
+
+        # Falls back to regex path because the sanitized list is empty
+        assert len(notes) == 2  # 2 NOTE entries from raw
+        assert "[patient]" in notes[0]["text"]
+
+    def test_empty_text_sanitized_notes_skipped(self):
+        """Sanitized notes with empty text should not appear in output."""
+        doc = _make_doc()
+        doc.analysis = _make_analysis(
+            sanitized_radio_notes=[
+                SanitizedNote(timestamp="2026-02-12T14:38:00", unit="E31", text=""),
+                SanitizedNote(
+                    timestamp="2026-02-12T14:42:00",
+                    unit="M31",
+                    text="transporting the patient",
+                ),
+            ]
+        )
+
+        notes = sanitize_radio_notes(doc)
+
+        assert len(notes) == 1
+        assert notes[0]["unit"] == "M31"
+
+    def test_html_entities_decoded(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis(
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="caller&#x27;s report",
+                ),
+            ]
+        )
+
+        notes = sanitize_radio_notes(doc)
+
+        assert notes[0]["text"] == "caller's report"
+
+    def test_no_responder_details(self):
+        doc = _make_doc(responder_details=[])
+        doc.analysis = DispatchAnalysis()
+
+        assert sanitize_radio_notes(doc) == []
+
+
+# ---------------------------------------------------------------------------
+# sanitize_dispatch_for_llm
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeDispatchForLlm:
+    def test_uses_sanitized_cad_comments(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        assert "13yo" not in result["cad_comments"]
+        assert "378-4141" not in result["cad_comments"]
+        assert "the patient" in result["cad_comments"]
+
+    def test_matches_sanitized_notes_by_timestamp_and_unit(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        # NOTE entries should have sanitized radio_log text
+        note_entries = [e for e in result["responder_details"] if e.get("status") == "NOTE"]
+        assert len(note_entries) == 2
+        for entry in note_entries:
+            assert "13yo" not in entry["radio_log"]
+            assert "72yo" not in entry["radio_log"]
+            assert "the patient" in entry["radio_log"]
+
+    def test_non_note_entries_untouched(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        # ENRT entry should be unchanged — no radio_log rewrite
+        enrt = next(e for e in result["responder_details"] if e.get("status") == "ENRT")
+        assert enrt["radio_log"] == "M31 enroute w/2"
+
+    def test_falls_back_to_regex_for_unmatched_note(self):
+        """NOTE entries with no sanitized match should be regex-redacted."""
+        doc = _make_doc()
+        # Only sanitize one of the two notes; the other should fall back
+        doc.analysis = _make_analysis(
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact the patient, alert",
+                ),
+                # Note for M31 at 14:42 intentionally missing
+            ]
+        )
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        notes_by_unit = {
+            e["unit_number"]: e["radio_log"]
+            for e in result["responder_details"]
+            if e.get("status") == "NOTE"
+        }
+        # E31: LLM-sanitized
+        assert "the patient, alert" in notes_by_unit["E31"]
+        # M31: regex fallback
+        assert "72yo" not in notes_by_unit["M31"]
+        assert "[patient]" in notes_by_unit["M31"]
+        assert "PeaceHealth" in notes_by_unit["M31"]
+
+    def test_fully_unenriched_doc_falls_back_to_regex(self):
+        doc = _make_doc()
+        doc.analysis = DispatchAnalysis()  # fully empty
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        # cad_comments: regex path
+        assert "13yo" not in result["cad_comments"]
+        assert "[patient]" in result["cad_comments"]
+        assert "[phone]" in result["cad_comments"]
+        # NOTE entries: regex path
+        note_entries = [e for e in result["responder_details"] if e.get("status") == "NOTE"]
+        for entry in note_entries:
+            assert "13yo" not in entry["radio_log"]
+            assert "72yo" not in entry["radio_log"]
+
+    def test_analysis_safety_net_redacts_summary_fields(self):
+        """Safety net: regex still scrubs summary/short_dsc/key_events.
+
+        Even if the enrichment LLM slips and leaves PII in its own output,
+        the regex pass should catch it.
+        """
+        doc = _make_doc()
+        doc.analysis = _make_analysis(
+            summary="13yo female fell from bike",
+            short_dsc="13yo fall",
+            key_events=["14:38 E31 — 72yo male pt contact"],
+        )
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        analysis = result["analysis"]
+        assert "13yo" not in analysis["summary"]
+        assert "[patient]" in analysis["summary"]
+        assert "13yo" not in analysis["short_dsc"]
+        assert "72yo" not in analysis["key_events"][0]
+
+    def test_does_not_mutate_source_doc(self):
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+        original_cad = doc.cad_comments
+        original_radio = doc.responder_details[0]["radio_log"]
+
+        sanitize_dispatch_for_llm(doc)
+
+        assert doc.cad_comments == original_cad
+        assert doc.responder_details[0]["radio_log"] == original_radio
+
+    def test_result_has_same_top_level_shape_as_to_dict(self):
+        """Claude expects the same keys as the raw dispatch dict."""
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        raw = doc.to_dict()
+        sanitized = sanitize_dispatch_for_llm(doc)
+
+        assert set(sanitized.keys()) == set(raw.keys())
+
+    def test_preserves_address_and_nature(self):
+        """Address is not PII — must pass through untouched."""
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        assert result["address"] == "200 Spring St"
+        assert result["city"] == "Friday Harbor"
+        assert result["nature"] == "Medical Aid"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: _prefill_from_dispatch uses sanitized fields
+# ---------------------------------------------------------------------------
+
+
+class TestPrefillFromDispatchSanitization:
+    @pytest.fixture(autouse=True)
+    def _clear_store(self):
+        from sjifire.ops.dispatch.store import DispatchStore
+
+        DispatchStore._memory.clear()
+        yield
+        DispatchStore._memory.clear()
+
+    async def test_prefill_uses_sanitized_cad_when_available(self):
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.incidents.tools import _prefill_from_dispatch
+
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        with patch.object(DispatchStore, "get_by_dispatch_id", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = doc
+            result = await _prefill_from_dispatch("26-001678")
+
+        # dispatch_comments: from LLM sanitized
+        assert "13yo" not in result["dispatch_comments"]
+        assert "378-4141" not in result["dispatch_comments"]
+        assert "the patient" in result["dispatch_comments"]
+
+        # dispatch_notes: should contain sanitized content, no raw PII
+        notes = result["dispatch_notes"]
+        assert notes  # non-empty
+        combined = " ".join(n.text for n in notes)
+        assert "13yo" not in combined
+        assert "72yo" not in combined
+        assert "John Smith" not in combined
+        # Operational content preserved
+        assert "PeaceHealth" in combined or "conscious" in combined
+
+    async def test_prefill_falls_back_to_regex_when_unenriched(self):
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.incidents.tools import _prefill_from_dispatch
+
+        doc = _make_doc()
+        doc.analysis = DispatchAnalysis()  # un-enriched
+
+        with patch.object(DispatchStore, "get_by_dispatch_id", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = doc
+            result = await _prefill_from_dispatch("26-001678")
+
+        # Still no raw PII — regex caught it
+        assert "13yo" not in result["dispatch_comments"]
+        assert "[patient]" in result["dispatch_comments"]
+
+        notes = result.get("dispatch_notes", [])
+        assert notes
+        combined = " ".join(n.text for n in notes)
+        assert "13yo" not in combined
+        assert "72yo" not in combined
+        assert "[patient]" in combined
+
+    async def test_prefill_preserves_address_untouched(self):
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.incidents.tools import _prefill_from_dispatch
+
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        with patch.object(DispatchStore, "get_by_dispatch_id", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = doc
+            result = await _prefill_from_dispatch("26-001678")
+
+        assert result["address"] == "200 Spring St"
+        assert result["city"] == "Friday Harbor"
+
+
+# ---------------------------------------------------------------------------
+# Human-facing surfaces (dashboard, chat sidebar) must still see RAW
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: MCP dispatch tools use sanitized output
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchMcpToolsSanitization:
+    @pytest.fixture(autouse=True)
+    def _clear_store(self):
+        from sjifire.ops.dispatch.store import DispatchStore
+
+        DispatchStore._memory.clear()
+        yield
+        DispatchStore._memory.clear()
+
+    @pytest.fixture
+    def auth_user(self):
+        from sjifire.ops.auth import UserContext, set_current_user
+
+        user = UserContext(email="ff@sjifire.org", name="FF", user_id="u1")
+        set_current_user(user)
+        yield user
+        set_current_user(None)
+
+    async def test_get_dispatch_call_returns_sanitized(self, auth_user):
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.dispatch.tools import get_dispatch_call
+
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        with patch.object(DispatchStore, "get_or_fetch", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = doc
+            with patch.object(
+                DispatchStore, "list_by_address", new_callable=AsyncMock
+            ) as mock_hist:
+                mock_hist.return_value = []
+                result = await get_dispatch_call("26-001678")
+
+        # cad_comments is sanitized
+        assert "13yo" not in result["cad_comments"]
+        assert "378-4141" not in result["cad_comments"]
+        assert "the patient" in result["cad_comments"]
+
+        # NOTE entries sanitized
+        note_entries = [e for e in result["responder_details"] if e.get("status") == "NOTE"]
+        for entry in note_entries:
+            assert "13yo" not in entry["radio_log"]
+            assert "72yo" not in entry["radio_log"]
+
+    async def test_list_dispatch_calls_returns_sanitized(self, auth_user):
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.dispatch.tools import list_dispatch_calls
+
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        with patch.object(
+            DispatchStore, "list_recent_with_open", new_callable=AsyncMock
+        ) as mock_list:
+            mock_list.return_value = [doc]
+            result = await list_dispatch_calls(days=7)
+
+        assert result["count"] == 1
+        call = result["calls"][0]
+        assert "13yo" not in call["cad_comments"]
+        assert "the patient" in call["cad_comments"]
+
+    async def test_search_by_dispatch_id_returns_sanitized(self, auth_user):
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.dispatch.tools import search_dispatch_calls
+
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        with patch.object(DispatchStore, "get_by_dispatch_id", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = doc
+            result = await search_dispatch_calls(dispatch_id="26-001678")
+
+        assert result["count"] == 1
+        assert "13yo" not in result["calls"][0]["cad_comments"]
+
+
+# ---------------------------------------------------------------------------
+# Human-facing surfaces (dashboard, chat sidebar) must still see RAW
+# ---------------------------------------------------------------------------
+
+
+class TestHumanFacingSurfacesStayRaw:
+    """Regression guard for the raw-vs-sanitized policy split.
+
+    Humans see raw; Claude sees sanitized. This test fails loudly if
+    someone accidentally wires sanitization into the dashboard or chat
+    sidebar.
+    """
+
+    def test_dispatch_call_document_to_dict_is_raw(self):
+        """``doc.to_dict()`` must return raw, unsanitized data.
+
+        It's called by dashboard + kiosk + chat sidebar — sanitization
+        is the caller's explicit choice, never the default.
+        """
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        raw = doc.to_dict()
+
+        # Raw PII should still be in to_dict output
+        assert "13yo female" in raw["cad_comments"]
+        assert "(360) 378-4141" in raw["cad_comments"]
+        assert "John Smith" in raw["cad_comments"]
+
+        # Raw radio_log in NOTE entries
+        e31_note = next(
+            e
+            for e in raw["responder_details"]
+            if e.get("status") == "NOTE" and e.get("unit_number") == "E31"
+        )
+        assert "13yo female" in e31_note["radio_log"]
+
+    def test_sanitize_does_not_mutate_doc(self):
+        """Sanitization must not leak into subsequent ``to_dict()`` calls.
+
+        After ``sanitize_dispatch_for_llm``, the next caller of
+        ``to_dict()`` should still see raw data.
+        """
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        _sanitized = sanitize_dispatch_for_llm(doc)
+        raw_after = doc.to_dict()
+
+        assert "13yo female" in raw_after["cad_comments"]

--- a/tests/ops/test_dispatch_sanitize.py
+++ b/tests/ops/test_dispatch_sanitize.py
@@ -9,6 +9,7 @@ Covers:
 - End-to-end wiring via chat engine slim dict
 """
 
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
@@ -373,6 +374,173 @@ class TestSanitizeDispatchForLlm:
         assert "[patient]" in notes_by_unit["M31"]
         assert "PeaceHealth" in notes_by_unit["M31"]
 
+    def test_extra_llm_notes_are_ignored(self):
+        """If the LLM invents a note not in ``responder_details``, ignore it.
+
+        We only walk ``responder_details`` and look up sanitized matches
+        by ``(timestamp, unit)``. Any LLM note that doesn't match a raw
+        entry is silently dropped — we don't invent radio log entries
+        from thin air.
+        """
+        doc = _make_doc()
+        doc.analysis = _make_analysis(
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact the patient, alert",
+                ),
+                SanitizedNote(
+                    timestamp="2026-02-12T14:42:00",
+                    unit="M31",
+                    text="transporting the patient",
+                ),
+                # Extra entry invented by the LLM — no matching raw entry
+                SanitizedNote(
+                    timestamp="2026-02-12T15:00:00",
+                    unit="BN31",
+                    text="command terminated",
+                ),
+            ]
+        )
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        # Only NOTE entries from raw responder_details should appear — the
+        # fabricated BN31 entry should NOT be added to the output.
+        note_units = [
+            e["unit_number"] for e in result["responder_details"] if e.get("status") == "NOTE"
+        ]
+        assert note_units == ["E31", "M31"]
+        assert "command terminated" not in json.dumps(result)
+
+    def test_timestamp_with_fractional_seconds_matches(self):
+        """Raw timestamps with microseconds should match LLM-truncated ones.
+
+        This is the common LLM behavior: raw iSpyFire sends
+        ``2026-02-12T14:38:00.123456`` and the enrichment LLM echoes
+        back ``2026-02-12T14:38:00`` (no fractional seconds). Without
+        timestamp normalization the lookup would miss and fall back to
+        regex — silently degrading sanitization quality.
+        """
+        doc = _make_doc(
+            responder_details=[
+                {
+                    "unit_number": "E31",
+                    "agency_code": "SJF",
+                    "status": "NOTE",
+                    # Raw has microseconds
+                    "time_of_status_change": "2026-02-12T14:38:00.123456",
+                    "radio_log": "pt contact 13yo female, conscious",
+                },
+            ]
+        )
+        doc.analysis = _make_analysis(
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    # LLM drops microseconds
+                    timestamp="2026-02-12T14:38:00",
+                    unit="E31",
+                    text="pt contact the patient, conscious",
+                ),
+            ]
+        )
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        note = next(e for e in result["responder_details"] if e.get("status") == "NOTE")
+        # LLM-sanitized text should be used (not regex fallback)
+        assert note["radio_log"] == "pt contact the patient, conscious"
+        # Raw PII should not appear
+        assert "13yo" not in note["radio_log"]
+
+    def test_timestamp_with_z_suffix_matches(self):
+        """Raw with ``Z`` suffix should match LLM echoing ``+00:00`` (or vice versa)."""
+        doc = _make_doc(
+            responder_details=[
+                {
+                    "unit_number": "E31",
+                    "agency_code": "SJF",
+                    "status": "NOTE",
+                    "time_of_status_change": "2026-02-12T14:38:00+00:00",
+                    "radio_log": "pt contact 13yo female",
+                },
+            ]
+        )
+        doc.analysis = _make_analysis(
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="2026-02-12T14:38:00Z",  # Z instead of +00:00
+                    unit="E31",
+                    text="pt contact the patient",
+                ),
+            ]
+        )
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        note = next(e for e in result["responder_details"] if e.get("status") == "NOTE")
+        assert note["radio_log"] == "pt contact the patient"
+        assert "13yo" not in note["radio_log"]
+
+    def test_timestamp_totally_unparseable_falls_back_exact_match(self):
+        """Non-ISO timestamps still work via exact string match."""
+        doc = _make_doc(
+            responder_details=[
+                {
+                    "unit_number": "E31",
+                    "agency_code": "SJF",
+                    "status": "NOTE",
+                    "time_of_status_change": "NOT_A_TIMESTAMP",
+                    "radio_log": "pt contact 13yo female",
+                },
+            ]
+        )
+        doc.analysis = _make_analysis(
+            sanitized_radio_notes=[
+                SanitizedNote(
+                    timestamp="NOT_A_TIMESTAMP",  # matches verbatim
+                    unit="E31",
+                    text="pt contact the patient",
+                ),
+            ]
+        )
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        note = next(e for e in result["responder_details"] if e.get("status") == "NOTE")
+        assert note["radio_log"] == "pt contact the patient"
+
+    def test_html_entities_in_raw_fallback_are_decoded(self):
+        """Regression for the fallback-path HTML entity bypass.
+
+        Raw radio_log containing HTML-encoded whitespace (``&#32;``)
+        would defeat the age regex if not unescaped first. This test
+        forces the fallback path (no sanitized_radio_notes) and an
+        HTML-encoded PII input that only the regex should see.
+        """
+        doc = _make_doc(
+            responder_details=[
+                {
+                    "unit_number": "E31",
+                    "agency_code": "SJF",
+                    "status": "NOTE",
+                    "time_of_status_change": "2026-02-12T14:38:00",
+                    # &#32; is HTML entity for space — would defeat \s+
+                    "radio_log": "pt contact 13yo&#32;female, conscious",
+                },
+            ]
+        )
+        doc.analysis = DispatchAnalysis()  # force regex fallback
+
+        result = sanitize_dispatch_for_llm(doc)
+
+        note = next(e for e in result["responder_details"] if e.get("status") == "NOTE")
+        # Regex must have matched after HTML-decode
+        assert "13yo" not in note["radio_log"]
+        assert "female" not in note["radio_log"]
+        assert "[patient]" in note["radio_log"]
+
     def test_fully_unenriched_doc_falls_back_to_regex(self):
         doc = _make_doc()
         doc.analysis = DispatchAnalysis()  # fully empty
@@ -605,6 +773,45 @@ class TestDispatchMcpToolsSanitization:
 
         assert result["count"] == 1
         assert "13yo" not in result["calls"][0]["cad_comments"]
+
+    async def test_get_open_dispatch_calls_returns_sanitized(self, auth_user):
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.dispatch.tools import get_open_dispatch_calls
+
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        with patch.object(DispatchStore, "fetch_open", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = [doc]
+            result = await get_open_dispatch_calls()
+
+        assert result["count"] == 1
+        call = result["calls"][0]
+        assert "13yo" not in call["cad_comments"]
+        assert "378-4141" not in call["cad_comments"]
+        assert "the patient" in call["cad_comments"]
+        note_entries = [e for e in call["responder_details"] if e.get("status") == "NOTE"]
+        for entry in note_entries:
+            assert "13yo" not in entry["radio_log"]
+            assert "72yo" not in entry["radio_log"]
+
+    async def test_search_by_date_range_returns_sanitized(self, auth_user):
+        """The date-range path of ``search_dispatch_calls`` also needs sanitization."""
+        from sjifire.ops.dispatch.store import DispatchStore
+        from sjifire.ops.dispatch.tools import search_dispatch_calls
+
+        doc = _make_doc()
+        doc.analysis = _make_analysis()
+
+        with patch.object(
+            DispatchStore, "list_by_date_range", new_callable=AsyncMock
+        ) as mock_range:
+            mock_range.return_value = [doc]
+            result = await search_dispatch_calls(start_date="2026-02-12", end_date="2026-02-12")
+
+        assert result["count"] == 1
+        assert "13yo" not in result["calls"][0]["cad_comments"]
+        assert "the patient" in result["calls"][0]["cad_comments"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Dispatch CAD comments and radio notes contain patient demographics ("13yo female injured in rear passenger seat", "9yo male stuck under car") that were flowing straight into incident narratives, the chat engine system prompt, and NERIS submissions.

This PR splits handling into two layers:

- **Raw** — stays untouched on `DispatchCallDocument` in Cosmos DB. Shown to humans on the dashboard, kiosk, and chat sidebar where full operational intelligence is needed.
- **Sanitized** — produced by the enrichment LLM as part of `DispatchAnalysis`, consumed by anything report-facing (MCP tools Claude calls, chat engine system prompt, incident document, NERIS submission).

### Architecture

| Surface | Data shown |
|---|---|
| Cosmos DB (source of truth) | **Raw** |
| Dashboard / kiosk | **Raw** |
| Chat sidebar (`chat_page` context) | **Raw** |
| MCP `get_dispatch_call` / `list_*` / etc. | **Sanitized** |
| Chat engine system prompt (`slim["cad_comments"]`) | **Sanitized** |
| Incident `dispatch_comments` / `dispatch_notes` (→ NERIS) | **Sanitized** |

### New fields on `DispatchAnalysis`

- `sanitized_cad_comments: str` — full CAD blob rewritten by LLM. Verbatim copy of the original with only patient/civilian demographics, names, and phone numbers stripped. Format, operational content, timestamps, unit codes, dispatcher names all preserved.
- `sanitized_radio_notes: list[SanitizedNote]` — NOTE entries from `responder_details`, rewritten, keyed by `(timestamp, unit)` so callers can match them back to raw.

### New helpers (`src/sjifire/ops/dispatch/sanitize.py`)

- `sanitize_cad_comments(doc)` — prefers LLM field, falls back to regex
- `sanitize_radio_notes(doc)` — prefers LLM field, falls back to regex
- `sanitize_dispatch_for_llm(doc)` — full dict for MCP tools; matches sanitized notes to raw by `(ts, unit)`, regex fallback for unmatched entries, safety-net regex pass on `analysis.summary` / `short_dsc` / `key_events`

### Call sites rewired

- `src/sjifire/ops/dispatch/tools.py` — all 4 MCP tools
- `src/sjifire/ops/chat/engine.py` — `slim["cad_comments"]`
- `src/sjifire/ops/incidents/tools.py` — `_prefill_from_dispatch` stores sanitized dispatch_comments + dispatch_notes on the incident

### Docs

- `docs/dispatch-cheatsheet.md` — enrichment LLM prompt updated with the two new fields and explicit sanitization rules (verbatim rewrite, not a summary; dispatcher names are not PII; preserve all operational content)
- `docs/neris/incident-report-instructions.md` — narrative PII rule added; example narratives updated to avoid patient demographics

## Test plan

- [x] `tests/core/test_pii.py` — 63 tests: regex age+gender, standalone age, phone numbers, caller names, operational preservation, edge cases (empty/None/multiline/HTML entities/realistic CAD blocks)
- [x] `tests/ops/test_dispatch_sanitize.py` — 31 tests: helper functions, LLM-vs-regex preference, NOTE matching by `(ts, unit)`, unmatched-note fallback, fully unenriched fallback, non-mutation, shape stability, MCP tool integration, `_prefill_from_dispatch` integration, regression guard that `doc.to_dict()` stays raw
- [x] Full test suite: 2630 passed, 7 skipped (no regressions)
- [x] `ruff check` + `ruff format` clean on all changed files
- [x] `ty check` clean on new files (pre-existing unrelated errors in `incidents/tools.py` untouched)

## Post-merge TODOs

- [ ] **Run dispatch re-enrichment backfill.** Existing stored calls don't have `sanitized_cad_comments` / `sanitized_radio_notes` populated until they go through the updated enrichment prompt. The regex fallback covers them in the meantime, but re-enriching gives everything the LLM-quality sanitization. Run once after merge + deploy:
  ```bash
  uv run ops-tasks dispatch-reenrich
  ```
  This is a manual (`auto=False`) task — it won't run automatically on the 30-minute schedule. It calls the LLM for every stored call, so expect meaningful API cost; run it once and monitor.
- [ ] **Verify the enrichment LLM produces the new fields on next `dispatch-sync` run** (Container Apps Job, every 30 min). Check a fresh call's `analysis.sanitized_cad_comments` in Cosmos to confirm the prompt change is wired in production.
- [ ] **Spot-check a report drafted by Claude after merge** — pick a medical call with obvious patient demographics in raw CAD and confirm the narrative Claude drafts contains no age/gender.
- [ ] **Consider adding `sanitized_*` field coverage to the dashboard QA smoke test** so regressions are caught end-to-end.

## Why regex + LLM (not just regex)

Regex catches the stock phrasings (`13yo female`, `72-year-old male`, phone numbers) but misses: "teenage girl", "elderly man", "female in her 70s", "pregnant woman", patient names, identifying medical details. The enrichment LLM already runs over every completed dispatch call; having it produce the sanitized version is dramatically more robust. Regex stays as the fallback for records that haven't been enriched yet (e.g., if the LLM provider was down when the call was ingested, or for historical calls before this PR).