### PR TITLE
Harden personal calendar sync against Outlook 429 throttling

### DIFF
--- a/.github/workflows/calendar-sync.yml
+++ b/.github/workflows/calendar-sync.yml
@@ -6,8 +6,9 @@ on:
     - cron: '0 17 * * *'  # 9am PST / 10am PDT
     - cron: '0 0 * * *'   # 4pm PST / 5pm PDT
     - cron: '0 3 * * *'   # 7pm PST / 8pm PDT
-    # Future months: 1x daily at noon Pacific
-    - cron: '0 20 * * *'  # 12pm PST / 1pm PDT
+    # Future months: 1x daily at 3am Pacific (off-hours to avoid Graph
+    # app-quota contention with entra-sync and ops-tasks)
+    - cron: '0 11 * * *'  # 3am PST / 4am PDT
   workflow_dispatch:
     inputs:
       dry_run:
@@ -103,8 +104,8 @@ jobs:
         run: |
           MAILBOX="all-personnel@sjifire.org"
           SCHEDULE_CACHE="/tmp/schedule.json"
-          # Noon schedule (0 20 * * *) syncs 4 months; others sync current month only
-          if [ "${{ github.event.schedule }}" = "0 20 * * *" ]; then
+          # 3am Pacific schedule (0 11 * * *) syncs 4 months; others sync current month only
+          if [ "${{ github.event.schedule }}" = "0 11 * * *" ]; then
             MONTHS="4"
           else
             MONTHS="${{ inputs.months || '1' }}"
@@ -120,7 +121,7 @@ jobs:
         run: |
           SCHEDULE_CACHE="/tmp/schedule.json"
           # Use same months as duty sync
-          if [ "${{ github.event.schedule }}" = "0 20 * * *" ]; then
+          if [ "${{ github.event.schedule }}" = "0 11 * * *" ]; then
             MONTHS="4"
           else
             MONTHS="${{ inputs.months || '1' }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Two types of calendar sync from Aladtec schedules to Outlook:
 - Compares events by key: `{date}|{subject}|{start_time}|{end_time}`
 - `--force` updates all events, `--purge` deletes all Aladtec events
 - `--load-schedule PATH` uses cached schedule instead of fetching from Aladtec
+- **Throttle handling**: Outlook caps concurrent requests at 4 per mailbox per app (`ApplicationThrottled / MailboxConcurrency`). Per-user concurrency is capped at 3, and on `--all` any user that sees a 429 is retried once at the end after a 60s cooldown. Kiota middleware also retries 429/503/504 at the HTTP layer (8 attempts, 5s initial backoff).
 
 **Schedule Caching** (reduces Aladtec API calls):
 ```bash
@@ -479,7 +480,7 @@ All secrets are centralized in Azure Key Vault `gh-website-utilities`. GitHub Ac
 - `ci.yml`: Lint + test + e2e on PR/push (e2e job runs Playwright chromium in parallel)
 - `entra-sync.yml`: Weekday sync at noon Pacific (user sync + group sync + signature sync), uploads backup artifacts
 - `ispyfire-sync.yml`: Daily iSpyFire state backup (dry-run sync + artifact upload). Actual sync runs every 30 min via Container Apps Job (`ops-tasks`)
-- `calendar-sync.yml`: Syncs duty + personal calendars (3x daily current month, 1x daily future months)
+- `calendar-sync.yml`: Syncs duty + personal calendars (3x daily current month at 9am/4pm/7pm Pacific, 1x daily 4-month lookahead at 3am Pacific)
 - `ops-deploy.yml`: Deploy ops server on push to main (paths: `src/sjifire/ops/**`, `Dockerfile`, `pyproject.toml`)
 
 All workflows authenticate via OIDC and fetch secrets from Key Vault (no GitHub secrets required).

--- a/src/sjifire/calendar/personal_sync.py
+++ b/src/sjifire/calendar/personal_sync.py
@@ -27,8 +27,10 @@ logger = logging.getLogger(__name__)
 
 # Timezone loaded from organization.json via get_timezone() / get_timezone_name().
 
-# Concurrency limit for parallel API calls
-MAX_CONCURRENT_REQUESTS = 5
+# Concurrency limit for parallel API calls per user mailbox.
+# Outlook's per-app-per-mailbox concurrency ceiling is 4 — we stay under it
+# to avoid MailboxConcurrency throttling (ApplicationThrottled 429s).
+MAX_CONCURRENT_REQUESTS = 3
 
 
 @dataclass
@@ -37,6 +39,18 @@ class ExistingEvent:
 
     event_id: str
     body: str
+
+
+def _is_throttled(exc: BaseException) -> bool:
+    """Return True if ``exc`` looks like a Graph 429 / throttling response.
+
+    Kiota's ``APIError`` exposes the HTTP status as ``response_status_code``.
+    """
+    status = getattr(exc, "response_status_code", None)
+    if status == 429:
+        return True
+    # Fallback: some wrappers put the code on ``.code``.
+    return getattr(exc, "code", None) == 429
 
 
 @dataclass
@@ -48,6 +62,7 @@ class PersonalSyncResult:
     events_updated: int = 0
     events_deleted: int = 0
     errors: list[str] = field(default_factory=list)
+    throttled: bool = False  # Set when a 429 was seen during this sync
 
     def __str__(self) -> str:  # noqa: D105
         parts = []
@@ -140,6 +155,9 @@ class PersonalCalendarSync:
         self.client = get_graph_client()
         self._calendar_cache: dict[str, str] = {}  # user_email -> calendar_id
         self._uses_primary_calendar: set[str] = set()  # users using primary calendar
+        # Set to True by any helper that observes a 429 during the current
+        # sync_user call. Reset at the top of sync_user.
+        self._throttled_this_run: bool = False
 
     async def ensure_aladtec_category(self, user_email: str) -> bool:
         """Ensure the Aladtec category exists in user's master category list.
@@ -182,7 +200,11 @@ class PersonalCalendarSync:
             if calendar and calendar.id:
                 return calendar.id
         except Exception as e:
-            logger.error("Failed to get primary calendar for %s: %s", user_email, e)
+            if _is_throttled(e):
+                self._throttled_this_run = True
+                logger.warning("Throttled getting primary calendar for %s", user_email)
+            else:
+                logger.error("Failed to get primary calendar for %s: %s", user_email, e)
         return None
 
     async def get_or_create_calendar(self, user_email: str) -> str | None:
@@ -286,7 +308,11 @@ class PersonalCalendarSync:
             return events_by_key
 
         except Exception as e:
-            logger.error("Failed to get existing events for %s: %s", user_email, e)
+            if _is_throttled(e):
+                self._throttled_this_run = True
+                logger.warning("Throttled getting existing events for %s", user_email)
+            else:
+                logger.error("Failed to get existing events for %s: %s", user_email, e)
             return {}
 
     def _build_personal_event(self, user_email: str, entry: ScheduleEntry) -> Event:
@@ -330,7 +356,11 @@ class PersonalCalendarSync:
             )
             return True
         except Exception as e:
-            logger.error("Failed to create event for %s: %s", user_email, e)
+            if _is_throttled(e):
+                self._throttled_this_run = True
+                logger.warning("Throttled creating event for %s", user_email)
+            else:
+                logger.error("Failed to create event for %s: %s", user_email, e)
             return False
 
     async def update_event(
@@ -352,7 +382,11 @@ class PersonalCalendarSync:
             )
             return True
         except Exception as e:
-            logger.error("Failed to update event %s: %s", event_id, e)
+            if _is_throttled(e):
+                self._throttled_this_run = True
+                logger.warning("Throttled updating event %s for %s", event_id, user_email)
+            else:
+                logger.error("Failed to update event %s: %s", event_id, e)
             return False
 
     async def delete_event(
@@ -371,7 +405,11 @@ class PersonalCalendarSync:
             )
             return True
         except Exception as e:
-            logger.error("Failed to delete event %s: %s", event_id, e)
+            if _is_throttled(e):
+                self._throttled_this_run = True
+                logger.warning("Throttled deleting event %s for %s", event_id, user_email)
+            else:
+                logger.error("Failed to delete event %s: %s", event_id, e)
             return False
 
     async def get_aladtec_category_events(
@@ -496,11 +534,17 @@ class PersonalCalendarSync:
             PersonalSyncResult with counts and errors
         """
         result = PersonalSyncResult(user=user_email)
+        # Reset throttle flag — it's per-sync_user-invocation.
+        self._throttled_this_run = False
 
         # Get or create calendar
         calendar_id = await self.get_or_create_calendar(user_email)
         if not calendar_id:
-            result.errors.append("Failed to get/create calendar")
+            if self._throttled_this_run:
+                result.throttled = True
+                result.errors.append("Throttled by Graph API (calendar fetch)")
+            else:
+                result.errors.append("Failed to get/create calendar")
             return result
 
         # Ensure Aladtec category exists in user's category list
@@ -595,6 +639,11 @@ class PersonalCalendarSync:
                 result.events_deleted = sum(1 for r in delete_results if r)
                 result.errors.extend(["Failed to delete event" for r in delete_results if not r])
 
+        # Propagate throttle signal to the caller. Set here (in addition to
+        # the early-return path above) so per-event 429s from parallel
+        # create/update/delete bursts still flag the user for retry.
+        if self._throttled_this_run:
+            result.throttled = True
         return result
 
     def sync(

--- a/src/sjifire/core/msgraph_client.py
+++ b/src/sjifire/core/msgraph_client.py
@@ -18,8 +18,8 @@ from sjifire.core.config import get_graph_credentials
 
 # Retry config for Graph API rate limiting (429) and transient errors (503/504).
 # Kiota's RetryHandler uses exponential backoff with jitter and respects Retry-After headers.
-GRAPH_MAX_RETRIES = 5
-GRAPH_RETRY_DELAY = 3.0  # initial delay in seconds
+GRAPH_MAX_RETRIES = 8
+GRAPH_RETRY_DELAY = 5.0  # initial delay in seconds
 
 
 def _create_retry_options() -> dict:

--- a/src/sjifire/scripts/personal_calendar_sync.py
+++ b/src/sjifire/scripts/personal_calendar_sync.py
@@ -38,6 +38,12 @@ logger = logging.getLogger(__name__)
 logging.getLogger("azure").setLevel(logging.WARNING)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
+# Pause between users so Outlook's rolling per-mailbox concurrency counters
+# have a moment to drain. Retry throttled users once at the end after a
+# longer cooldown — per-mailbox throttles usually clear by then.
+INTER_USER_PAUSE_SEC = 1.0
+THROTTLE_RETRY_COOLDOWN_SEC = 60.0
+
 
 def parse_month(month_str: str) -> tuple[int, int]:
     """Parse a month string into (year, month)."""
@@ -349,7 +355,8 @@ def main() -> int:
     sync = PersonalCalendarSync()
 
     async def sync_all() -> list:
-        results = []
+        results: list = []
+        throttled_emails: list[str] = []
         for email, entries in entries_by_email.items():
             logger.info("Syncing %s (%d entries)...", email, len(entries))
             result = await sync.sync_user(
@@ -357,6 +364,32 @@ def main() -> int:
             )
             results.append(result)
             logger.info("  %s", result)
+            if result.throttled:
+                throttled_emails.append(email)
+            await asyncio.sleep(INTER_USER_PAUSE_SEC)
+
+        if throttled_emails:
+            logger.warning(
+                "Retrying %d throttled user(s) after %.0fs cooldown: %s",
+                len(throttled_emails),
+                THROTTLE_RETRY_COOLDOWN_SEC,
+                ", ".join(throttled_emails),
+            )
+            await asyncio.sleep(THROTTLE_RETRY_COOLDOWN_SEC)
+            for email in throttled_emails:
+                entries = entries_by_email[email]
+                logger.info("Retry: Syncing %s (%d entries)...", email, len(entries))
+                retry_result = await sync.sync_user(
+                    email, entries, start_date, end_date, args.dry_run, args.force
+                )
+                logger.info("  %s", retry_result)
+                # Replace the original (failed) result with the retry outcome.
+                for i, r in enumerate(results):
+                    if r.user == email:
+                        results[i] = retry_result
+                        break
+                await asyncio.sleep(INTER_USER_PAUSE_SEC)
+
         return results
 
     results = asyncio.run(sync_all())

--- a/tests/test_msgraph_client.py
+++ b/tests/test_msgraph_client.py
@@ -126,5 +126,5 @@ class TestCreateGraphClient:
 
     def test_retry_constants(self):
         """Retry constants should be reasonable values."""
-        assert GRAPH_MAX_RETRIES == 5
-        assert GRAPH_RETRY_DELAY == 3.0
+        assert GRAPH_MAX_RETRIES == 8
+        assert GRAPH_RETRY_DELAY == 5.0

--- a/tests/test_personal_calendar_sync.py
+++ b/tests/test_personal_calendar_sync.py
@@ -950,3 +950,133 @@ class TestSyncUserErrorAccumulation:
         )
 
         assert len([e for e in result.errors if "delete" in e.lower()]) == 1
+
+
+class TestSyncUserThrottleDetection:
+    """Tests that 429 responses surface via PersonalSyncResult.throttled."""
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        """Mock environment variables for Graph API credentials."""
+        with patch.dict(
+            "os.environ",
+            {
+                "MS_GRAPH_TENANT_ID": "test-tenant",
+                "MS_GRAPH_CLIENT_ID": "test-client",
+                "MS_GRAPH_CLIENT_SECRET": "test-secret",
+            },
+        ):
+            yield
+
+    @pytest.fixture
+    def sync(self, mock_env_vars):
+        """Create PersonalCalendarSync with mocked client."""
+        with (
+            patch("sjifire.calendar.personal_sync.get_graph_client") as mock_client_class,
+        ):
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            sync = PersonalCalendarSync()
+            sync.client = mock_client
+            return sync
+
+    @staticmethod
+    def _throttle_error() -> Exception:
+        """Build an exception shaped like a Kiota 429 APIError."""
+        exc = Exception("Application is over its MailboxConcurrency limit.")
+        exc.response_status_code = 429
+        return exc
+
+    @pytest.mark.asyncio
+    async def test_get_primary_calendar_sets_throttled_flag(self, sync):
+        """A 429 on /calendar sets _throttled_this_run and returns None."""
+        sync.client.users.by_user_id.return_value.calendar.get = AsyncMock(
+            side_effect=self._throttle_error()
+        )
+
+        result = await sync._get_primary_calendar_id("test@example.com")
+        assert result is None
+        assert sync._throttled_this_run is True
+
+    @pytest.mark.asyncio
+    async def test_get_primary_calendar_non_throttle_does_not_set_flag(self, sync):
+        """Non-429 errors do not mark the run as throttled."""
+        sync.client.users.by_user_id.return_value.calendar.get = AsyncMock(
+            side_effect=Exception("Some other error")
+        )
+
+        result = await sync._get_primary_calendar_id("test@example.com")
+        assert result is None
+        assert sync._throttled_this_run is False
+
+    @pytest.mark.asyncio
+    async def test_sync_user_surfaces_throttle_on_calendar_fetch(self, sync):
+        """sync_user returns throttled=True when calendar fetch is throttled."""
+        # Force the calendar fetch to 429.
+        sync.client.users.by_user_id.return_value.calendar.get = AsyncMock(
+            side_effect=self._throttle_error()
+        )
+
+        result = await sync.sync_user(
+            "test@example.com",
+            [],
+            date(2026, 2, 1),
+            date(2026, 2, 28),
+        )
+
+        assert result.throttled is True
+        assert result.errors  # Throttled fetch still counts as an error
+        assert any("Throttled" in e for e in result.errors)
+
+    @pytest.mark.asyncio
+    async def test_create_event_sets_throttled_flag_on_429(self, sync):
+        """create_event's except block flips _throttled_this_run on 429."""
+        entry = ScheduleEntry(
+            date=date(2026, 2, 1),
+            section="S31",
+            position="Captain",
+            name="John Doe",
+            start_time="18:00",
+            end_time="18:00",
+        )
+        # Skip _build_personal_event (needs Aladtec creds) and go straight
+        # to the Graph call that we want to throttle.
+        sync._build_personal_event = MagicMock(return_value=MagicMock())
+        sync.client.users.by_user_id.return_value.calendars.by_calendar_id.return_value.events.post = AsyncMock(
+            side_effect=self._throttle_error()
+        )
+
+        ok = await sync.create_event("test@example.com", "cal-id", entry)
+        assert ok is False
+        assert sync._throttled_this_run is True
+
+    @pytest.mark.asyncio
+    async def test_delete_event_sets_throttled_flag_on_429(self, sync):
+        """delete_event's except block flips _throttled_this_run on 429."""
+        sync.client.users.by_user_id.return_value.calendars.by_calendar_id.return_value.events.by_event_id.return_value.delete = AsyncMock(
+            side_effect=self._throttle_error()
+        )
+
+        ok = await sync.delete_event("test@example.com", "cal-id", "evt-id")
+        assert ok is False
+        assert sync._throttled_this_run is True
+
+    @pytest.mark.asyncio
+    async def test_throttle_flag_resets_between_users(self, sync):
+        """_throttled_this_run is reset at the top of each sync_user call."""
+        sync.get_or_create_calendar = AsyncMock(return_value="cal-id")
+        sync.ensure_aladtec_category = AsyncMock(return_value=True)
+        sync.get_existing_events = AsyncMock(return_value={})
+
+        # Simulate the flag being left set by a prior run.
+        sync._throttled_this_run = True
+
+        result = await sync.sync_user(
+            "test@example.com",
+            [],
+            date(2026, 2, 1),
+            date(2026, 2, 28),
+        )
+
+        assert result.throttled is False
+        assert sync._throttled_this_run is False

--- a/tests/test_personal_calendar_sync_script.py
+++ b/tests/test_personal_calendar_sync_script.py
@@ -391,6 +391,62 @@ class TestMainWithUserFlag:
         mock_personal_sync.sync_user.assert_not_called()
 
 
+class TestMainThrottleRetry:
+    """Tests for the end-of-run retry loop for throttled users."""
+
+    def test_throttled_user_is_retried_after_cooldown(
+        self, mock_env_vars, mock_member_scraper, mock_schedule_scraper, mock_personal_sync
+    ):
+        """A user flagged as throttled is retried once after the run."""
+        # First call per user returns throttled for agreene, normal for jsmith.
+        # Second call (the retry) for agreene returns success.
+        call_log: list[tuple[str, bool]] = []
+
+        async def fake_sync_user(email, entries, start, end, dry_run, force):
+            throttled_first_time = email == "agreene@sjifire.org" and (email, True) not in call_log
+            call_log.append((email, throttled_first_time))
+            if throttled_first_time:
+                return PersonalSyncResult(
+                    user=email, throttled=True, errors=["Throttled by Graph API"]
+                )
+            return PersonalSyncResult(user=email, events_created=1)
+
+        mock_personal_sync.sync_user = AsyncMock(side_effect=fake_sync_user)
+
+        # Skip real sleeps so the 60s cooldown doesn't slow the test.
+        with (
+            patch.object(sys, "argv", ["personal-calendar-sync", "--all", "--month", "Feb 2026"]),
+            patch("sjifire.scripts.personal_calendar_sync.asyncio.sleep", new=AsyncMock()),
+        ):
+            result = main()
+
+        # 2 users initial pass + 1 retry for agreene = 3 calls.
+        assert mock_personal_sync.sync_user.call_count == 3
+        agreene_calls = [c for c in call_log if c[0] == "agreene@sjifire.org"]
+        assert len(agreene_calls) == 2  # once throttled, once retried
+        # Successful retry means no net error → exit 0.
+        assert result == 0
+
+    def test_throttled_user_still_throttled_on_retry_exits_nonzero(
+        self, mock_env_vars, mock_member_scraper, mock_schedule_scraper, mock_personal_sync
+    ):
+        """If the retry also throttles, the error is surfaced as exit 1."""
+
+        async def always_throttled(email, entries, start, end, dry_run, force):
+            return PersonalSyncResult(user=email, throttled=True, errors=["Throttled by Graph API"])
+
+        mock_personal_sync.sync_user = AsyncMock(side_effect=always_throttled)
+
+        with (
+            patch.object(sys, "argv", ["personal-calendar-sync", "--all", "--month", "Feb 2026"]),
+            patch("sjifire.scripts.personal_calendar_sync.asyncio.sleep", new=AsyncMock()),
+        ):
+            result = main()
+
+        # Retry still failed → nonzero exit.
+        assert result == 1
+
+
 class TestMainWithForceFlag:
     """Tests for main() with --force flag."""
 

--- a/tests/test_personal_sync.py
+++ b/tests/test_personal_sync.py
@@ -10,6 +10,7 @@ from sjifire.aladtec.schedule_scraper import ScheduleEntry
 from sjifire.calendar.personal_sync import (
     ExistingEvent,
     PersonalSyncResult,
+    _is_throttled,
     _parse_graph_datetime,
     make_event_body,
     make_event_subject,
@@ -123,6 +124,42 @@ class TestPersonalSyncResult:
         """Shows error count."""
         result = PersonalSyncResult(user="test@example.com", errors=["error1", "error2"])
         assert str(result) == "test@example.com: 2 errors"
+
+    def test_throttled_defaults_false(self):
+        """Throttled flag defaults to False."""
+        result = PersonalSyncResult(user="test@example.com")
+        assert result.throttled is False
+
+    def test_throttled_can_be_set(self):
+        """Throttled flag can be set to True."""
+        result = PersonalSyncResult(user="test@example.com", throttled=True)
+        assert result.throttled is True
+
+
+class TestIsThrottled:
+    """Tests for the _is_throttled helper."""
+
+    def test_detects_429_via_response_status_code(self):
+        """Kiota APIError exposes HTTP status on response_status_code."""
+        exc = Exception("boom")
+        exc.response_status_code = 429
+        assert _is_throttled(exc) is True
+
+    def test_detects_429_via_code_fallback(self):
+        """Falls back to .code for wrappers that put the status there."""
+        exc = Exception("boom")
+        exc.code = 429
+        assert _is_throttled(exc) is True
+
+    def test_non_429_status_is_not_throttled(self):
+        """500/503/other errors are not reported as throttled."""
+        exc = Exception("boom")
+        exc.response_status_code = 503
+        assert _is_throttled(exc) is False
+
+    def test_exception_with_no_status_is_not_throttled(self):
+        """Plain exception without status attributes is not throttled."""
+        assert _is_throttled(Exception("boom")) is False
 
     def test_str_with_multiple_changes(self):
         """Shows multiple change types."""


### PR DESCRIPTION
Root cause of the Calendar Sync #246 failure (and the earlier one this
week): personal-calendar-sync issued 5 concurrent requests per user,
above Outlook's per-app-per-mailbox concurrency ceiling of 4. That
tripped "ApplicationThrottled / MailboxConcurrency" 429s on individual
mailboxes (cgenther@sjifire.org in this run), Kiota's 5-retry / 3s
budget wasn't long enough to ride out the cooldown, and the bare
except in _get_primary_calendar_id swallowed the error into a single
counted failure that forced the whole job to exit 1.

Changes:
- Drop per-user concurrency from 5 -> 3 (stays below the 4 ceiling).
- Bump Kiota retry budget from 5/3.0s -> 8/5.0s for longer backoff.
- Detect 429 in all Graph call sites in personal_sync.py and surface
  it via PersonalSyncResult.throttled instead of silently counting an
  error.
- In the --all loop, pause 1s between users and retry any throttled
  users once at the end after a 60s cooldown, replacing the failed
  result with the retry outcome.