### PR TITLE
Add FirePreventionStrategy for fire prevention group management

### DIFF
--- a/src/sjifire/core/group_strategies.py
+++ b/src/sjifire/core/group_strategies.py
@@ -571,7 +571,7 @@ class FirePreventionStrategy(AllPersonnelStrategy):
         """Return group configuration."""
         return GroupConfig(
             display_name="Fire Prevention",
-            mail_nickname="fire-prevention",
+            mail_nickname="fireprevention",
             description="Fire prevention - shared calendar and email distribution.",
             enforce_calendar_visibility=True,  # Group calendar must appear in Outlook
         )

--- a/src/sjifire/core/group_strategies.py
+++ b/src/sjifire/core/group_strategies.py
@@ -543,6 +543,40 @@ class AllPersonnelStrategy(GroupStrategy):
         return "\n".join(lines)
 
 
+class FirePreventionStrategy(AllPersonnelStrategy):
+    """Strategy for Fire Prevention M365 group membership.
+
+    Same eligibility as All Personnel (everyone in the department), with a
+    shared group calendar enforced into Outlook for fire prevention events,
+    inspections, and public education activities.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return strategy name."""
+        return "fire-prevention"
+
+    def get_members(self, members: list[GroupMember]) -> dict[str, list[GroupMember]]:
+        """Return members for the Fire Prevention group."""
+        eligible = [
+            m
+            for m in members
+            if self._is_active(m)
+            and self._has_aladtec_record(m)
+            and (self._is_staff(m) or self._has_operational_position(m))
+        ]
+        return {"fire-prevention": eligible}
+
+    def get_config(self, group_key: str) -> GroupConfig:
+        """Return group configuration."""
+        return GroupConfig(
+            display_name="Fire Prevention",
+            mail_nickname="fire-prevention",
+            description="Fire prevention - shared calendar and email distribution.",
+            enforce_calendar_visibility=True,  # Group calendar must appear in Outlook
+        )
+
+
 # Registry of all available strategies
 STRATEGY_CLASSES: dict[str, type[GroupStrategy]] = {
     "stations": StationStrategy,
@@ -555,6 +589,7 @@ STRATEGY_CLASSES: dict[str, type[GroupStrategy]] = {
     "staff": StaffStrategy,
     "mobe": MobeScheduleStrategy,
     "all-personnel": AllPersonnelStrategy,
+    "fire-prevention": FirePreventionStrategy,
 }
 
 # List of strategy names for CLI

--- a/src/sjifire/scripts/ms_group_sync.py
+++ b/src/sjifire/scripts/ms_group_sync.py
@@ -1034,6 +1034,7 @@ async def backup_groups(
             "volunteers": ["Volunteers"],
             "mobe": ["mobe"],
             "all-personnel": ["all-personnel"],
+            "fire-prevention": ["fire-prevention"],
         }
         for key in sample_keys.get(strategy_name, [strategy_name]):
             try:

--- a/tests/test_group_strategies.py
+++ b/tests/test_group_strategies.py
@@ -9,6 +9,7 @@ from sjifire.core.group_strategies import (
     AllPersonnelStrategy,
     ApparatusOperatorStrategy,
     FirefighterStrategy,
+    FirePreventionStrategy,
     GroupConfig,
     GroupMember,
     GroupStrategy,
@@ -104,6 +105,7 @@ class TestStrategyRegistry:
             "staff",
             "mobe",
             "all-personnel",
+            "fire-prevention",
         }
         assert set(STRATEGY_CLASSES.keys()) == expected
 
@@ -985,6 +987,64 @@ class TestAllPersonnelStrategy:
         assert config.enforce_calendar_visibility is True
 
 
+class TestFirePreventionStrategy:
+    """Tests for FirePreventionStrategy - everyone, with shared calendar."""
+
+    def setup_method(self):
+        """Create strategy instance for each test."""
+        self.strategy = FirePreventionStrategy()
+
+    def test_name(self):
+        """Strategy name should be 'fire-prevention'."""
+        assert self.strategy.name == "fire-prevention"
+
+    def test_partial_sync_is_true(self):
+        """FirePreventionStrategy should have partial_sync=True."""
+        assert self.strategy.partial_sync is True
+
+    def test_get_members_uses_fire_prevention_key(self):
+        """get_members should return a 'fire-prevention' key, not 'all-personnel'."""
+        members = [
+            make_member(member_id="1", email="staff@sjifire.org", work_group="Career"),
+        ]
+        result = self.strategy.get_members(members)
+        assert "fire-prevention" in result
+        assert "all-personnel" not in result
+        assert len(result["fire-prevention"]) == 1
+
+    def test_get_members_includes_staff_and_operational_volunteers(self):
+        """Should include staff and volunteers with operational positions."""
+        members = [
+            make_member(member_id="1", email="staff@sjifire.org", work_group="Career"),
+            make_member(
+                member_id="2",
+                email="volff@sjifire.org",
+                work_group="Volunteer",
+                positions=["Firefighter"],
+            ),
+            make_member(
+                member_id="3",
+                email="admin@sjifire.org",
+                work_group="Volunteer",
+                positions=["Administrative"],
+            ),
+        ]
+        result = self.strategy.get_members(members)
+        emails = {m.email for m in result["fire-prevention"]}
+        assert emails == {"staff@sjifire.org", "volff@sjifire.org"}
+
+    def test_get_config(self):
+        """get_config should return proper GroupConfig."""
+        config = self.strategy.get_config("fire-prevention")
+        assert config.display_name == "Fire Prevention"
+        assert config.mail_nickname == "fire-prevention"
+
+    def test_get_config_enforce_calendar_visibility(self):
+        """Calendar must auto-appear in members' Outlook."""
+        config = self.strategy.get_config("fire-prevention")
+        assert config.enforce_calendar_visibility is True
+
+
 # =============================================================================
 # AllPersonnelStrategy Internal Methods Tests
 # =============================================================================
@@ -1410,10 +1470,16 @@ class TestGroupStrategyContract:
         strategy = get_strategy("all-personnel")
         assert strategy.partial_sync is True
 
+    def test_fire_prevention_strategy_has_partial_sync_true(self):
+        """FirePreventionStrategy should have partial_sync=True."""
+        strategy = get_strategy("fire-prevention")
+        assert strategy.partial_sync is True
+
     def test_other_strategies_have_partial_sync_false(self):
-        """Strategies other than all-personnel should have partial_sync=False."""
+        """Strategies other than all-personnel and fire-prevention should have partial_sync=False."""
+        partial_sync_strategies = {"all-personnel", "fire-prevention"}
         for name in STRATEGY_NAMES:
-            if name != "all-personnel":
+            if name not in partial_sync_strategies:
                 strategy = get_strategy(name)
                 assert strategy.partial_sync is False, f"{name} should have partial_sync=False"
 

--- a/tests/test_group_strategies.py
+++ b/tests/test_group_strategies.py
@@ -1037,7 +1037,7 @@ class TestFirePreventionStrategy:
         """get_config should return proper GroupConfig."""
         config = self.strategy.get_config("fire-prevention")
         assert config.display_name == "Fire Prevention"
-        assert config.mail_nickname == "fire-prevention"
+        assert config.mail_nickname == "fireprevention"
 
     def test_get_config_enforce_calendar_visibility(self):
         """Calendar must auto-appear in members' Outlook."""


### PR DESCRIPTION
## Summary
This PR introduces a new `FirePreventionStrategy` to manage a dedicated Fire Prevention M365 group with shared calendar functionality. The strategy extends `AllPersonnelStrategy` to include staff and operational volunteers with enforced calendar visibility in Outlook.

## Key Changes
- **New Strategy Class**: Added `FirePreventionStrategy` that inherits from `AllPersonnelStrategy`
  - Returns members under the "fire-prevention" key instead of "all-personnel"
  - Includes staff and volunteers with operational positions (same eligibility as all-personnel)
  - Configures group with display name "Fire Prevention" and mail nickname "fireprevention"
  - Enforces calendar visibility so the shared calendar auto-appears in members' Outlook

- **Registry Updates**: 
  - Added "fire-prevention" entry to `STRATEGY_CLASSES` dictionary
  - Updated test expectations to include the new strategy in the registry

- **Test Coverage**: Added comprehensive test suite (`TestFirePreventionStrategy`) covering:
  - Strategy name and partial_sync flag
  - Member filtering logic (includes staff and operational volunteers, excludes administrative volunteers)
  - Group configuration (display name, mail nickname, calendar visibility enforcement)
  - Integration with strategy lookup functions

- **Backup Script**: Updated `ms_group_sync.py` to include "fire-prevention" in backup group mappings

## Implementation Details
- `FirePreventionStrategy` leverages inherited eligibility checks from `AllPersonnelStrategy` (`_is_active`, `_has_aladtec_record`, `_is_staff`, `_has_operational_position`)
- Marked as `partial_sync=True` (inherited) to enable incremental synchronization
- Calendar visibility enforcement ensures the shared calendar is automatically visible to all members in their Outlook clients

https://claude.ai/code/session_015PzQKhP63jL3rvAG9YT6Dg